### PR TITLE
登録画面のプレゼンテーションロジックを作成

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,5 @@
 github "MatiBot/MBCircularProgressBar"
+github "Daltron/NotificationBanner" "master"
 
 ## firebase
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,7 @@
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json" "7.11.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "7.11.0"
+github "Daltron/NotificationBanner" "2ce5c49d8ee4865f01a3ce3bbe078664c78c7a3c"
 github "MatiBot/MBCircularProgressBar" "0.3.4"
+github "SnapKit/SnapKit" "5.0.1"
+github "cbpowell/MarqueeLabel" "4.0.5"

--- a/PatientMoney.xcodeproj/project.pbxproj
+++ b/PatientMoney.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3D3A3223263EEFE000077B6D /* NotificationBanner.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3D3A3224263EEFE000077B6D /* SnapKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321F263EEFE000077B6D /* SnapKit.xcframework */; };
 		3D3A3225263EEFE000077B6D /* SnapKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321F263EEFE000077B6D /* SnapKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D3A322A263EF37F00077B6D /* RegisterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A3229263EF37F00077B6D /* RegisterPresenter.swift */; };
 		3D6B0FDD263D8031009D21A1 /* HeightSelfSizingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */; };
 		3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FE6263D85E0009D21A1 /* DateView.swift */; };
 		3D6B0FEC263E714D009D21A1 /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FEB263E714D009D21A1 /* DateUtils.swift */; };
@@ -115,6 +116,7 @@
 		3D3A321D263EEFE000077B6D /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
 		3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NotificationBanner.xcframework; path = Carthage/Build/NotificationBanner.xcframework; sourceTree = "<group>"; };
 		3D3A321F263EEFE000077B6D /* SnapKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapKit.xcframework; path = Carthage/Build/SnapKit.xcframework; sourceTree = "<group>"; };
+		3D3A3229263EF37F00077B6D /* RegisterPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPresenter.swift; sourceTree = "<group>"; };
 		3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightSelfSizingCollectionView.swift; sourceTree = "<group>"; };
 		3D6B0FE6263D85E0009D21A1 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		3D6B0FEB263E714D009D21A1 /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
@@ -264,6 +266,14 @@
 				3DE103C72638360000F724B8 /* Strings.swift */,
 			);
 			name = Generated;
+			sourceTree = "<group>";
+		};
+		3D3A3228263EF36D00077B6D /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				3D3A3229263EF37F00077B6D /* RegisterPresenter.swift */,
+			);
+			path = Presenter;
 			sourceTree = "<group>";
 		};
 		3D6B0FEA263E713E009D21A1 /* Util */ = {
@@ -486,6 +496,7 @@
 		3DE104AE263D3BC700F724B8 /* PatienceRegister */ = {
 			isa = PBXGroup;
 			children = (
+				3D3A3228263EF36D00077B6D /* Presenter */,
 				3D6B1007263E9A6D009D21A1 /* View */,
 				3D3A3215263EE0F700077B6D /* RegisterContract.swift */,
 			);
@@ -686,6 +697,7 @@
 				3D3A3216263EE0F700077B6D /* RegisterContract.swift in Sources */,
 				3DE10449263C725200F724B8 /*  AuthInteractor.swift in Sources */,
 				3DE1049A263D36E900F724B8 /* NSAttributedStrinfExtension.swift in Sources */,
+				3D3A322A263EF37F00077B6D /* RegisterPresenter.swift in Sources */,
 				3D6B1009263E9A82009D21A1 /* RegisterViewController.swift in Sources */,
 				3D6B0FDD263D8031009D21A1 /* HeightSelfSizingCollectionView.swift in Sources */,
 				3D6B0FEC263E714D009D21A1 /* DateUtils.swift in Sources */,

--- a/PatientMoney.xcodeproj/project.pbxproj
+++ b/PatientMoney.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3D205C6326381C820058064C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3D205C6226381C820058064C /* Localizable.strings */; };
 		3D205C6B26381EAB0058064C /* gRPCCertificates-Cpp.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 3D205C6A26381EAB0058064C /* gRPCCertificates-Cpp.bundle */; };
+		3D3A3216263EE0F700077B6D /* RegisterContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A3215263EE0F700077B6D /* RegisterContract.swift */; };
 		3D6B0FDD263D8031009D21A1 /* HeightSelfSizingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */; };
 		3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FE6263D85E0009D21A1 /* DateView.swift */; };
 		3D6B0FEC263E714D009D21A1 /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FEB263E714D009D21A1 /* DateUtils.swift */; };
@@ -99,6 +100,7 @@
 /* Begin PBXFileReference section */
 		3D205C6226381C820058064C /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		3D205C6A26381EAB0058064C /* gRPCCertificates-Cpp.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = "gRPCCertificates-Cpp.bundle"; path = "../../Carthage/Build/iOS/gRPC-C++.framework/Resources/gRPCCertificates-Cpp.bundle"; sourceTree = "<group>"; };
+		3D3A3215263EE0F700077B6D /* RegisterContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterContract.swift; sourceTree = "<group>"; };
 		3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightSelfSizingCollectionView.swift; sourceTree = "<group>"; };
 		3D6B0FE6263D85E0009D21A1 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		3D6B0FEB263E714D009D21A1 /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 			isa = PBXGroup;
 			children = (
 				3D6B1007263E9A6D009D21A1 /* View */,
+				3D3A3215263EE0F700077B6D /* RegisterContract.swift */,
 			);
 			path = PatienceRegister;
 			sourceTree = "<group>";
@@ -659,6 +662,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DE10427263C008900F724B8 /* SignUpViewController.swift in Sources */,
+				3D3A3216263EE0F700077B6D /* RegisterContract.swift in Sources */,
 				3DE10449263C725200F724B8 /*  AuthInteractor.swift in Sources */,
 				3DE1049A263D36E900F724B8 /* NSAttributedStrinfExtension.swift in Sources */,
 				3D6B1009263E9A82009D21A1 /* RegisterViewController.swift in Sources */,

--- a/PatientMoney.xcodeproj/project.pbxproj
+++ b/PatientMoney.xcodeproj/project.pbxproj
@@ -3,13 +3,20 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		3D205C6326381C820058064C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3D205C6226381C820058064C /* Localizable.strings */; };
 		3D205C6B26381EAB0058064C /* gRPCCertificates-Cpp.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 3D205C6A26381EAB0058064C /* gRPCCertificates-Cpp.bundle */; };
 		3D3A3216263EE0F700077B6D /* RegisterContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A3215263EE0F700077B6D /* RegisterContract.swift */; };
+		3D3A321A263EEEA000077B6D /* StatusNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A3219263EEEA000077B6D /* StatusNotification.swift */; };
+		3D3A3220263EEFE000077B6D /* MarqueeLabel.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321D263EEFE000077B6D /* MarqueeLabel.xcframework */; };
+		3D3A3221263EEFE000077B6D /* MarqueeLabel.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321D263EEFE000077B6D /* MarqueeLabel.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D3A3222263EEFE000077B6D /* NotificationBanner.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */; };
+		3D3A3223263EEFE000077B6D /* NotificationBanner.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D3A3224263EEFE000077B6D /* SnapKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321F263EEFE000077B6D /* SnapKit.xcframework */; };
+		3D3A3225263EEFE000077B6D /* SnapKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D3A321F263EEFE000077B6D /* SnapKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3D6B0FDD263D8031009D21A1 /* HeightSelfSizingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */; };
 		3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FE6263D85E0009D21A1 /* DateView.swift */; };
 		3D6B0FEC263E714D009D21A1 /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FEB263E714D009D21A1 /* DateUtils.swift */; };
@@ -90,7 +97,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				3D3A3225263EEFE000077B6D /* SnapKit.xcframework in Embed Frameworks */,
+				3D3A3223263EEFE000077B6D /* NotificationBanner.xcframework in Embed Frameworks */,
 				3D6D012726355E4400C30DD1 /* MBCircularProgressBar.framework in Embed Frameworks */,
+				3D3A3221263EEFE000077B6D /* MarqueeLabel.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -101,6 +111,10 @@
 		3D205C6226381C820058064C /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		3D205C6A26381EAB0058064C /* gRPCCertificates-Cpp.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = "gRPCCertificates-Cpp.bundle"; path = "../../Carthage/Build/iOS/gRPC-C++.framework/Resources/gRPCCertificates-Cpp.bundle"; sourceTree = "<group>"; };
 		3D3A3215263EE0F700077B6D /* RegisterContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterContract.swift; sourceTree = "<group>"; };
+		3D3A3219263EEEA000077B6D /* StatusNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusNotification.swift; sourceTree = "<group>"; };
+		3D3A321D263EEFE000077B6D /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
+		3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NotificationBanner.xcframework; path = Carthage/Build/NotificationBanner.xcframework; sourceTree = "<group>"; };
+		3D3A321F263EEFE000077B6D /* SnapKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapKit.xcframework; path = Carthage/Build/SnapKit.xcframework; sourceTree = "<group>"; };
 		3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightSelfSizingCollectionView.swift; sourceTree = "<group>"; };
 		3D6B0FE6263D85E0009D21A1 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		3D6B0FEB263E714D009D21A1 /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
@@ -189,7 +203,9 @@
 			files = (
 				3D6D012826355E4400C30DD1 /* nanopb.framework in Frameworks */,
 				3D6D010626355E4300C30DD1 /* BoringSSL-GRPC.framework in Frameworks */,
+				3D3A3220263EEFE000077B6D /* MarqueeLabel.xcframework in Frameworks */,
 				3D6D011626355E4400C30DD1 /* FirebaseInstallations.framework in Frameworks */,
+				3D3A3222263EEFE000077B6D /* NotificationBanner.xcframework in Frameworks */,
 				3D6D011E26355E4400C30DD1 /* gRPC-C++.framework in Frameworks */,
 				3D6D011826355E4400C30DD1 /* GoogleAppMeasurement.framework in Frameworks */,
 				3D6D012226355E4400C30DD1 /* GTMSessionFetcher.framework in Frameworks */,
@@ -204,6 +220,7 @@
 				3D6D011A26355E4400C30DD1 /* GoogleDataTransport.framework in Frameworks */,
 				3D6D012626355E4400C30DD1 /* MBCircularProgressBar.framework in Frameworks */,
 				3D6D012026355E4400C30DD1 /* gRPC-Core.framework in Frameworks */,
+				3D3A3224263EEFE000077B6D /* SnapKit.xcframework in Frameworks */,
 				3D6D010A26355E4300C30DD1 /* Firebase.framework in Frameworks */,
 				3D6D011C26355E4400C30DD1 /* GoogleUtilities.framework in Frameworks */,
 				3D6D010C26355E4300C30DD1 /* FirebaseAnalytics.framework in Frameworks */,
@@ -253,6 +270,7 @@
 			isa = PBXGroup;
 			children = (
 				3D6B0FEB263E714D009D21A1 /* DateUtils.swift */,
+				3D3A3219263EEEA000077B6D /* StatusNotification.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -328,6 +346,9 @@
 		3D6DFF8A263548B200C30DD1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3D3A321D263EEFE000077B6D /* MarqueeLabel.xcframework */,
+				3D3A321E263EEFE000077B6D /* NotificationBanner.xcframework */,
+				3D3A321F263EEFE000077B6D /* SnapKit.xcframework */,
 				3D6D012D26355E4500C30DD1 /* MBCircularProgressBar.framework.dSYM */,
 				3D6D00AD26355BA500C30DD1 /* abseil.framework */,
 				3D6D00A226355BA400C30DD1 /* BoringSSL-GRPC.framework */,
@@ -673,6 +694,7 @@
 				3D6B0FF6263E76AA009D21A1 /* DescriptionView.swift in Sources */,
 				3D6B1000263E94E1009D21A1 /* MoneyView.swift in Sources */,
 				3DE10495263D36B500F724B8 /* FontAwesome.swift in Sources */,
+				3D3A321A263EEEA000077B6D /* StatusNotification.swift in Sources */,
 				3DE1041A263BEDE900F724B8 /* FlatButton.swift in Sources */,
 				3DE103F4263AE67F00F724B8 /* PatienceTextField.swift in Sources */,
 				3DE103CC2638360800F724B8 /* Asset.swift in Sources */,

--- a/PatientMoney/Generated/Strings.swift
+++ b/PatientMoney/Generated/Strings.swift
@@ -126,6 +126,18 @@ internal enum L10n {
   }
 
   internal enum RegisterViewController {
+    internal enum Alert {
+      /// 金額が０円ですがこのまま登録しますか？
+      internal static let title = L10n.tr("Localizable", "RegisterViewController.Alert.title")
+      internal enum CancelAction {
+        /// キャンセル
+        internal static let title = L10n.tr("Localizable", "RegisterViewController.Alert.CancelAction.title")
+      }
+      internal enum OkAction {
+        /// OK
+        internal static let title = L10n.tr("Localizable", "RegisterViewController.Alert.OkAction.title")
+      }
+    }
     internal enum NavigationItem {
       /// 登録画面
       internal static let title = L10n.tr("Localizable", "RegisterViewController.NavigationItem.title")

--- a/PatientMoney/PatienceRegister/Presenter/RegisterPresenter.swift
+++ b/PatientMoney/PatienceRegister/Presenter/RegisterPresenter.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class RegisterPresenter: RegisterPresentation, RegisterInteractorOutput {
+    // MARK: RegisterPresentation
+    var view: RegisterView?
+
+    var interactor: RegisterUsecase!
+
+    var router: AuthWireFrame!
+
+    func didTapRegisterButton(patience: Patience) {
+        outputRegisterSuccess()
+//        interactor.registerPatienceData(date: patience.date, description: patience.discription, money: patience.money, category: patience.category) { [weak self] (error) in
+//            if let error = error{
+//                self?.outputRegisterError(error: error)
+//            }else {
+//                self?.outputRegisterSuccess()
+//            }
+//        }
+    }
+
+    // MARK: RegisterInteractorOutput
+    func outputRegisterError(error: Error) {
+        view?.showError(message: "error")
+    }
+
+    func outputRegisterSuccess() {
+        view?.showError(message: "success")
+    }
+}

--- a/PatientMoney/PatienceRegister/Presenter/RegisterPresenter.swift
+++ b/PatientMoney/PatienceRegister/Presenter/RegisterPresenter.swift
@@ -10,13 +10,13 @@ class RegisterPresenter: RegisterPresentation, RegisterInteractorOutput {
 
     func didTapRegisterButton(patience: Patience) {
         outputRegisterSuccess()
-//        interactor.registerPatienceData(date: patience.date, description: patience.discription, money: patience.money, category: patience.category) { [weak self] (error) in
-//            if let error = error{
-//                self?.outputRegisterError(error: error)
-//            }else {
-//                self?.outputRegisterSuccess()
-//            }
-//        }
+        interactor.registerPatienceData(date: patience.date, description: patience.discription, money: patience.money, category: patience.category) { [weak self] error in
+            if let error = error {
+                self?.outputRegisterError(error: error)
+            } else {
+                self?.outputRegisterSuccess()
+            }
+        }
     }
 
     // MARK: RegisterInteractorOutput

--- a/PatientMoney/PatienceRegister/RegisterContract.swift
+++ b/PatientMoney/PatienceRegister/RegisterContract.swift
@@ -43,7 +43,8 @@ protocol RegisterUsecase {
     /// - parameter discription:メモ
     /// - parameter money: 金額
     /// - parameter category: カテゴリー
-    func registerPatienceData(date: Date, description: String, money: Int, category: String)
+    /// - parameter completion: 完了ハンドラ
+    func registerPatienceData(date: Date, description: String, money: Int, category: String, completion: (Error?) -> Void)
 }
 
 protocol RegisterInteractorOutput {

--- a/PatientMoney/PatienceRegister/RegisterContract.swift
+++ b/PatientMoney/PatienceRegister/RegisterContract.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+struct PatienceEntity{
+    var date:Date
+    var discription:String
+    var money:Int
+    var category:String
+}
+
+protocol RegisterWireframe{
+    // Dependency
+    var viewController: UIViewController? { get }
+}
+
+protocol RegisterView{
+    // Dependency
+    var presenter: RegisterPresentation! { get }
+    /// エラーメッセージを表示する
+    /// - parameter message:エラーメッセージ
+    func showError(message: String)
+}
+
+protocol RegisterPresentation{
+    // Dependency
+    var view: RegisterView? { get }
+    var interactor: RegisterUsecase! { get }
+    var router: AuthWireFrame! { get }
+    /// 登録ボタンがタップされた
+    /// - parameter patience:登録項目
+    func didTapRegisterButton(patience:PatienceEntity)
+}
+
+protocol RegisterUsecase{
+    // Dependency
+    var output: AuthInteractorOutput? { get }
+    /// データを登録する
+    /// - parameter date:日付
+    /// - parameter discription:メモ
+    /// - parameter money: 金額
+    /// - parameter category: カテゴリー
+    func registerPatienceData(date:Date,description:String,money:Int,category:String)
+}
+
+protocol RegisterInteractorOutput{
+    /// 登録時のエラーを知らせる
+    /// - parameter error:エラー内容
+    func outputRegisterError(error:Error)
+    
+    /// 登録に成功したことを知らせる
+    func outputRegisterSuccess()
+    
+}
+
+protocol RegisterRepository{
+    /// データを登録する
+    /// - parameter date:日付
+    /// - parameter discription:メモ
+    /// - parameter money: 金額
+    /// - parameter category: カテゴリー
+    func registerPatienceData(date:Date,description:String,money:Int,category:String)
+}

--- a/PatientMoney/PatienceRegister/RegisterContract.swift
+++ b/PatientMoney/PatienceRegister/RegisterContract.swift
@@ -1,37 +1,41 @@
 import Foundation
 import UIKit
 
-struct PatienceEntity{
-    var date:Date
-    var discription:String
-    var money:Int
-    var category:String
+struct Patience {
+    var date: Date
+    var discription: String
+    var money: Int
+    var category: String
 }
 
-protocol RegisterWireframe{
+protocol RegisterWireframe {
     // Dependency
     var viewController: UIViewController? { get }
 }
 
-protocol RegisterView{
+protocol RegisterView {
     // Dependency
     var presenter: RegisterPresentation! { get }
     /// エラーメッセージを表示する
     /// - parameter message:エラーメッセージ
     func showError(message: String)
+
+    /// 成功メッセージを表示する
+    /// - parameter message:成功メッセージ
+    func showSuccess(message: String)
 }
 
-protocol RegisterPresentation{
+protocol RegisterPresentation {
     // Dependency
     var view: RegisterView? { get }
     var interactor: RegisterUsecase! { get }
     var router: AuthWireFrame! { get }
     /// 登録ボタンがタップされた
     /// - parameter patience:登録項目
-    func didTapRegisterButton(patience:PatienceEntity)
+    func didTapRegisterButton(patience: Patience)
 }
 
-protocol RegisterUsecase{
+protocol RegisterUsecase {
     // Dependency
     var output: AuthInteractorOutput? { get }
     /// データを登録する
@@ -39,24 +43,23 @@ protocol RegisterUsecase{
     /// - parameter discription:メモ
     /// - parameter money: 金額
     /// - parameter category: カテゴリー
-    func registerPatienceData(date:Date,description:String,money:Int,category:String)
+    func registerPatienceData(date: Date, description: String, money: Int, category: String)
 }
 
-protocol RegisterInteractorOutput{
+protocol RegisterInteractorOutput {
     /// 登録時のエラーを知らせる
     /// - parameter error:エラー内容
-    func outputRegisterError(error:Error)
-    
+    func outputRegisterError(error: Error)
+
     /// 登録に成功したことを知らせる
     func outputRegisterSuccess()
-    
 }
 
-protocol RegisterRepository{
+protocol RegisterRepository {
     /// データを登録する
     /// - parameter date:日付
     /// - parameter discription:メモ
     /// - parameter money: 金額
     /// - parameter category: カテゴリー
-    func registerPatienceData(date:Date,description:String,money:Int,category:String)
+    func registerPatienceData(date: Date, description: String, money: Int, category: String)
 }

--- a/PatientMoney/PatienceRegister/View/RegisterViewController.swift
+++ b/PatientMoney/PatienceRegister/View/RegisterViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class RegisterViewController: UIViewController {
+class RegisterViewController: UIViewController, RegisterView {
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -39,6 +39,19 @@ class RegisterViewController: UIViewController {
         ])
     }
 
+    // MARK: RegisterView
+    var presenter: RegisterPresentation!
+
+    func showError(message: String) {
+        StatusNotification.notifyError(message)
+    }
+
+    func showSuccess(message: String) {
+        StatusNotification.notifySuccess(message)
+    }
+
+    // MARK: Private
+
     private let vstack = UIStackView()
 
     private let subViews = [
@@ -49,4 +62,15 @@ class RegisterViewController: UIViewController {
     ]
 
     private let registerButton = UIButton()
+    
+    @objc private func registerButtonAction(_ :UIButton){
+        if let date = (subViews[0] as? DateView)?.selectedDate,
+           let discription = (subViews[1] as? DescriptionView)?.memo,
+           let money = (subViews[2] as? MoneyView )?.money,
+           let category = (subViews[3] as? CategoriesView)?.selectedCategoryTitle
+        {
+            let patience = Patience(date: date, discription: discription, money: money, category: category)
+            presenter.didTapRegisterButton(patience: patience)
+        }
+    }
 }

--- a/PatientMoney/PatienceRegister/View/RegisterViewController.swift
+++ b/PatientMoney/PatienceRegister/View/RegisterViewController.swift
@@ -65,11 +65,11 @@ class RegisterViewController: UIViewController, RegisterView {
     private let registerButton = UIButton()
 
     private lazy var alert: UIAlertController = {
-        let alert = UIAlertController(title: nil, message: "金額が０円ですが、このまま登録しますか？", preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "OK", style: .default, handler: { [weak self] _ in
+        let alert = UIAlertController(title: nil, message: L10n.RegisterViewController.Alert.title, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: L10n.RegisterViewController.Alert.OkAction.title, style: .default, handler: { [weak self] _ in
             self?.registerAction()
         })
-        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: { [weak self] _ in
+        let cancelAction = UIAlertAction(title: L10n.RegisterViewController.Alert.CancelAction.title, style: .cancel, handler: { [weak self] _ in
             self?.cancelAction()
         })
         alert.addAction(okAction)

--- a/PatientMoney/PatienceRegister/View/RegisterViewController.swift
+++ b/PatientMoney/PatienceRegister/View/RegisterViewController.swift
@@ -24,6 +24,7 @@ class RegisterViewController: UIViewController, RegisterView {
         registerButton.setTitle(L10n.RegisterViewController.RegisterButton.title, for: .normal)
         registerButton.backgroundColor = .orange
         registerButton.layer.cornerRadius = 10
+        registerButton.addTarget(self, action: #selector(registerButtonAction(_:)), for: .touchUpInside)
         view.addSubview(registerButton)
 
         NSLayoutConstraint.activate([
@@ -62,15 +63,36 @@ class RegisterViewController: UIViewController, RegisterView {
     ]
 
     private let registerButton = UIButton()
-    
-    @objc private func registerButtonAction(_ :UIButton){
+
+    private lazy var alert: UIAlertController = {
+        let alert = UIAlertController(title: nil, message: "金額が０円ですが、このまま登録しますか？", preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "OK", style: .default, handler: { [weak self] _ in
+            self?.registerAction()
+        })
+        let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: { [weak self] _ in
+            self?.cancelAction()
+        })
+        alert.addAction(okAction)
+        alert.addAction(cancelAction)
+        return alert
+    }()
+
+    private func registerAction() {
+    }
+
+    private func cancelAction() {
+    }
+
+    @objc private func registerButtonAction(_ :UIButton) {
         if let date = (subViews[0] as? DateView)?.selectedDate,
            let discription = (subViews[1] as? DescriptionView)?.memo,
-           let money = (subViews[2] as? MoneyView )?.money,
-           let category = (subViews[3] as? CategoriesView)?.selectedCategoryTitle
-        {
-            let patience = Patience(date: date, discription: discription, money: money, category: category)
-            presenter.didTapRegisterButton(patience: patience)
+           let category = (subViews[3] as? CategoriesView)?.selectedCategoryTitle {
+            if let money = (subViews[2] as? MoneyView)?.money {
+                let patience = Patience(date: date, discription: discription, money: money, category: category)
+                presenter.didTapRegisterButton(patience: patience)
+            } else {
+                present(alert, animated: true, completion: nil)
+            }
         }
     }
 }

--- a/PatientMoney/PatienceRegister/View/ViewComponent/CategoriesView.swift
+++ b/PatientMoney/PatienceRegister/View/ViewComponent/CategoriesView.swift
@@ -4,7 +4,7 @@ import UIKit
 /// カテゴリーView
 class CategoriesView: UIView {
     /// 選択されたカテゴリータイトル
-    var selectedCategoryTitle: String = ""
+    var selectedCategoryTitle: String = L10n.CategoriesView.IconTitle.pizzaSlice
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/PatientMoney/PatienceRegister/View/ViewComponent/DateView.swift
+++ b/PatientMoney/PatienceRegister/View/ViewComponent/DateView.swift
@@ -31,7 +31,7 @@ class DateView: UIView {
         addSubview(titleLabel)
 
         dateTextField.translatesAutoresizingMaskIntoConstraints = false
-        dateTextField.placeholder = DateUtils.stringFromDate(date: Date(), format: dateFormat)
+        dateTextField.text = DateUtils.stringFromDate(date: Date(), format: dateFormat)
         dateTextField.backgroundColor = UIColor(hex: "F0E68C")
         dateTextField.textInsets = UIEdgeInsets(top: 5, left: 20, bottom: 5, right: 20)
         dateTextField.font = UIFont.boldSystemFont(ofSize: 20)

--- a/PatientMoney/PatienceRegister/View/ViewComponent/MoneyView.swift
+++ b/PatientMoney/PatienceRegister/View/ViewComponent/MoneyView.swift
@@ -3,12 +3,12 @@ import UIKit
 
 class MoneyView: UIView {
     /// 金額
-    var money: Int {
+    var money: Int? {
         get {
-            Int(moneyTextField.text ?? "") ?? 0
+            Int(moneyTextField.text ?? "")
         }
         set {
-            moneyTextField.text = String(newValue)
+            moneyTextField.text = String(newValue ?? 0)
         }
     }
 

--- a/PatientMoney/Resources/Localizable.strings
+++ b/PatientMoney/Resources/Localizable.strings
@@ -41,3 +41,7 @@
 // RegisterViewController
 "RegisterViewController.RegisterButton.title" = "登録する";
 "RegisterViewController.NavigationItem.title" = "登録画面";
+"RegisterViewController.Alert.OkAction.title" = "OK";
+"RegisterViewController.Alert.CancelAction.title" = "キャンセル";
+"RegisterViewController.Alert.title" = "金額が０円ですがこのまま登録しますか？";
+

--- a/PatientMoney/Util/StatusNotification.swift
+++ b/PatientMoney/Util/StatusNotification.swift
@@ -1,0 +1,31 @@
+import Foundation
+import MarqueeLabel
+import NotificationBanner
+
+/// ユーザーへの状態通知
+struct StatusNotification {
+    /// Success通知
+    static func notifySuccess(_ message: String, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        let banner = StatusBarNotificationBanner(title: message, style: .success)
+        banner.haptic = .light
+        banner.duration = 0.25
+        banner.show()
+    }
+
+    /// Error通知
+    static func notifyError(_ message: String, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        let banner = StatusBarNotificationBanner(title: message, style: .danger)
+        if let titleLabel = banner.titleLabel as? MarqueeLabel {
+            titleLabel.type = .left
+            titleLabel.animationDelay = 1
+        }
+        banner.haptic = .heavy
+        banner.duration = 2
+        banner.show()
+    }
+
+    // MARK: - Private
+
+    private init() {
+    }
+}


### PR DESCRIPTION
登録画面のプレゼンテーションロジックを作成した。
金額が０円の時は登録ボタン押下時にアラートで確認ダイアログを表示するようにした。
また、カテゴリーについてはデフォルトで飲食費を選択済みにし、日付も現在の日にちをデフォルトでテキストに反映しておくようにした。
登録の結果通知を行いたかったので、そのために[Notification Banner](https://github.com/Daltron/NotificationBanner)を導入した