### PR TITLE
アプリのDisplayNameの変更

### DIFF
--- a/PatientMoney/Info.plist
+++ b/PatientMoney/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ja_JP</string>
 	<key>CFBundleDisplayName</key>
-	<string>PatientMoney</string>
+	<string>節約家計簿</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
アプリアイコンの下に表示されるアプリ名がストア表示名と違ったのでストア用に合わせた