### PR TITLE
カレンダー画面においてtableviewのヘッダーが切り替わらない不具合の対応

### DIFF
--- a/PatientMoney.xcodeproj/project.pbxproj
+++ b/PatientMoney.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		3D3A3231263F074F00077B6D /* PatienceInputInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A3230263F074F00077B6D /* PatienceInputInteractor.swift */; };
 		3D3A323F263F096B00077B6D /* PatienceDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A323E263F096B00077B6D /* PatienceDataStore.swift */; };
 		3D3A3250263F2B9800077B6D /* PatienceInputRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3A324F263F2B9800077B6D /* PatienceInputRouter.swift */; };
+		3D61B4E2264EDA2F001C74B6 /* RecordListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D61B4E1264EDA2F001C74B6 /* RecordListHeaderView.swift */; };
 		3D6B0FDD263D8031009D21A1 /* HeightSelfSizingCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */; };
 		3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FE6263D85E0009D21A1 /* DateView.swift */; };
 		3D6B0FEC263E714D009D21A1 /* DateUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0FEB263E714D009D21A1 /* DateUtils.swift */; };
@@ -142,6 +143,7 @@
 		3D3A3230263F074F00077B6D /* PatienceInputInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceInputInteractor.swift; sourceTree = "<group>"; };
 		3D3A323E263F096B00077B6D /* PatienceDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceDataStore.swift; sourceTree = "<group>"; };
 		3D3A324F263F2B9800077B6D /* PatienceInputRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceInputRouter.swift; sourceTree = "<group>"; };
+		3D61B4E1264EDA2F001C74B6 /* RecordListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordListHeaderView.swift; sourceTree = "<group>"; };
 		3D6B0FDC263D8031009D21A1 /* HeightSelfSizingCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightSelfSizingCollectionView.swift; sourceTree = "<group>"; };
 		3D6B0FE6263D85E0009D21A1 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		3D6B0FEB263E714D009D21A1 /* DateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateUtils.swift; sourceTree = "<group>"; };
@@ -316,6 +318,7 @@
 		3D36BC90263FBF0600EDF69F /* View */ = {
 			isa = PBXGroup;
 			children = (
+				3D61B4E0264EDA04001C74B6 /* ViewComponents */,
 				3D36BC91263FBF1A00EDF69F /* PatienceCalendarViewController.swift */,
 			);
 			path = View;
@@ -370,6 +373,14 @@
 				3D3A324F263F2B9800077B6D /* PatienceInputRouter.swift */,
 			);
 			path = Router;
+			sourceTree = "<group>";
+		};
+		3D61B4E0264EDA04001C74B6 /* ViewComponents */ = {
+			isa = PBXGroup;
+			children = (
+				3D61B4E1264EDA2F001C74B6 /* RecordListHeaderView.swift */,
+			);
+			path = ViewComponents;
 			sourceTree = "<group>";
 		};
 		3D6B0FEA263E713E009D21A1 /* Util */ = {
@@ -863,6 +874,7 @@
 				3DE103CC2638360800F724B8 /* Asset.swift in Sources */,
 				3D36BC99263FD39200EDF69F /* HeightSelfSizingTableView.swift in Sources */,
 				3DEE39A0264112C4005D3EB0 /* PatienceEntity.swift in Sources */,
+				3D61B4E2264EDA2F001C74B6 /* RecordListHeaderView.swift in Sources */,
 				3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */,
 				3DE10408263B976700F724B8 /* AuthContract.swift in Sources */,
 				3DE103E6263ACBE100F724B8 /* AuthViewController.swift in Sources */,

--- a/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -65,6 +65,8 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     private let calendar = FSCalendar()
 
+    private let recordListHeaderView = RecordListHeaderView()
+
     private lazy var recordsView: UITableView = {
         let view = UITableView()
         view.register(RecordCell.self, forCellReuseIdentifier: RecordCell.reuseIdentifer)
@@ -93,7 +95,12 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 // MARK: UITableViewDelegate, UITableViewDataSource
 extension PatienceCalenderViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        20
+        44
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        recordListHeaderView.title = DateUtils.stringFromDate(date: date, format: DateUtils.dateFormatJapanese)
+        return recordListHeaderView
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -123,6 +130,7 @@ extension PatienceCalenderViewController: UITableViewDelegate, UITableViewDataSo
 extension PatienceCalenderViewController: FSCalendarDelegate, FSCalendarDataSource {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         self.date = DateUtils.getStartDay(date: date)
+        recordListHeaderView.title = DateUtils.stringFromDate(date: date, format: DateUtils.dateFormatJapanese)
         present(alert, animated: true, completion: nil)
     }
 }

--- a/PatientMoney/Module/PatienceCalendar/View/ViewComponents/RecordListHeaderView.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/ViewComponents/RecordListHeaderView.swift
@@ -1,0 +1,45 @@
+//
+//  RecordListHeaderView.swift
+//  PatientMoney
+//
+//  Created by 松山響也 on 2021/05/15.
+//
+
+import Foundation
+import UIKit
+
+/// 記録リストHeaderView
+class RecordListHeaderView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        construct()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        construct()
+    }
+
+    ///　taitoru
+    var title: String = ""{
+        didSet {
+            titleLabel.text = title
+        }
+    }
+
+    private func construct() {
+        backgroundColor = .white
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 15)
+        titleLabel.textColor = .black
+        addSubview(titleLabel)
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 44),
+            titleLabel.rightAnchor.constraint(equalTo: rightAnchor, constant: -10),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    private let titleLabel = UILabel()
+}


### PR DESCRIPTION
カレンダー画面においてtableviewのヘッダーが切り替わらない不具合の対応をした
ヘッダー用のViewを作成し、そのViewのプロパティを変更することで実現させた