### PR TITLE
登録画面の各タイトルの文字を太字の14pxに揃える

### DIFF
--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/CategoriesView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/CategoriesView.swift
@@ -25,7 +25,7 @@ class CategoriesView: UIView {
         addSubview(categoriesView)
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 20)
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
         titleLabel.text = L10n.CategoriesView.title
         addSubview(titleLabel)
 

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/DateView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/DateView.swift
@@ -27,7 +27,7 @@ class DateView: UIView {
     private func construct() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.DateView.title
-        titleLabel.font = UIFont.systemFont(ofSize: 20)
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
         addSubview(titleLabel)
 
         dateTextField.translatesAutoresizingMaskIntoConstraints = false

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/MemoView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/MemoView.swift
@@ -25,7 +25,7 @@ class MemoView: UIView {
     // MARK: Private
     private func construct() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.systemFont(ofSize: 20)
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
         titleLabel.text = L10n.MemoView.title
         addSubview(titleLabel)
 

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/MoneyView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/MoneyView.swift
@@ -27,7 +27,7 @@ class MoneyView: UIView {
     private func construct() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.MoneyView.title
-        titleLabel.font = UIFont.systemFont(ofSize: 20)
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
         addSubview(titleLabel)
 
         moneyTextField.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
タイトル通り
登録画面の各タイトルが不揃えだったので揃えた
![IMG_7590](https://user-images.githubusercontent.com/63186144/119257060-9886f200-bbfe-11eb-8c25-f3140cdb36cd.PNG)
