### PR TITLE
モーダルを閉じた時に登録したデータが反映されていない問題を修正

### DIFF
--- a/PatientMoney/Module/PatienceCalendar/Router/PatienceCalendarRouter.swift
+++ b/PatientMoney/Module/PatienceCalendar/Router/PatienceCalendarRouter.swift
@@ -31,7 +31,7 @@ class PatienceCalendarRouter: PatienceCalendarWireframe {
 
     func presentRegisterModal(date: Date) {
         let registerView = PatienceInputRouter.assembleRegisterModule(date: date)
-        viewController?.navigationController?.pushViewController(registerView, animated: true)
+        viewController?.present(registerView, animated: true, completion: nil)
     }
 
     func presentUpdateView(record: PatienceEntity) {

--- a/PatientMoney/Module/PatienceCalendar/Router/PatienceCalendarRouter.swift
+++ b/PatientMoney/Module/PatienceCalendar/Router/PatienceCalendarRouter.swift
@@ -31,6 +31,7 @@ class PatienceCalendarRouter: PatienceCalendarWireframe {
 
     func presentRegisterModal(date: Date) {
         let registerView = PatienceInputRouter.assembleRegisterModule(date: date)
+        registerView.presentationController?.delegate = viewController as? PatienceCalenderViewController
         viewController?.present(registerView, animated: true, completion: nil)
     }
 

--- a/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -54,7 +54,6 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     func showSuccess(message: String) {
         StatusNotification.notifySuccess(message)
-        updateRecordsView()
     }
 
     func updateRecord(records: [PatienceEntity]) {

--- a/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -38,7 +38,6 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
             recordsView.widthAnchor.constraint(equalToConstant: view.frame.width),
             recordsView.heightAnchor.constraint(equalToConstant: view.frame.height * 0.4 )
         ])
-        presenter.selectedDateDidChange(date: DateUtils.getStartDay(date: Date()))
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -55,6 +54,7 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     func showSuccess(message: String) {
         StatusNotification.notifySuccess(message)
+        updateRecordsView()
     }
 
     func updateRecord(records: [PatienceEntity]) {
@@ -89,6 +89,10 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     private func didTapRegisterButton() {
         presenter.didTapRegisterButton(date: date)
+    }
+
+    private func updateRecordsView() {
+        presenter.selectedDateDidChange(date: date)
     }
 }
 
@@ -132,6 +136,12 @@ extension PatienceCalenderViewController: FSCalendarDelegate, FSCalendarDataSour
         self.date = DateUtils.getStartDay(date: date)
         recordListHeaderView.title = DateUtils.stringFromDate(date: date, format: DateUtils.dateFormatJapanese)
         present(alert, animated: true, completion: nil)
+    }
+}
+
+extension PatienceCalenderViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        updateRecordsView()
     }
 }
 

--- a/PatientMoney/Module/PatienceRegister/PatienceRegisterContract.swift
+++ b/PatientMoney/Module/PatienceRegister/PatienceRegisterContract.swift
@@ -8,6 +8,9 @@ protocol PatienceInputWireframe {
 
     ///  登録画面を閉じる
     func closeInputView()
+
+    /// 登録画面モーダルを閉じる
+    func dismissInputModal()
 }
 
 protocol PatienceInputView {

--- a/PatientMoney/Module/PatienceRegister/Presenter/PatienceInputPresenter.swift
+++ b/PatientMoney/Module/PatienceRegister/Presenter/PatienceInputPresenter.swift
@@ -25,7 +25,7 @@ class PatienceInputPresenter: PatienceInputPresentation, PatienceInputInteractor
     }
 
     func outputRegisterSuccess() {
-        router.closeInputView()
+        router.dismissInputModal()
         view?.showSuccess(message: L10n.PatienceInputPresenter.StatusNotification.RegisterSuccess.title)
     }
 

--- a/PatientMoney/Module/PatienceRegister/Router/PatienceInputRouter.swift
+++ b/PatientMoney/Module/PatienceRegister/Router/PatienceInputRouter.swift
@@ -57,6 +57,7 @@ class PatienceInputRouter: PatienceInputWireframe {
         guard let presentationController = viewController?.presentationController else {
             return
         }
+        /// dismissで閉じた場合にはdelegateメソッドが起動しないのでここで明示的に呼んでいる
         viewController?.presentationController?.delegate?.presentationControllerDidDismiss?(presentationController)
     }
 }

--- a/PatientMoney/Module/PatienceRegister/Router/PatienceInputRouter.swift
+++ b/PatientMoney/Module/PatienceRegister/Router/PatienceInputRouter.swift
@@ -51,4 +51,12 @@ class PatienceInputRouter: PatienceInputWireframe {
     func closeInputView() {
         viewController?.navigationController?.popViewController(animated: true)
     }
+
+    func dismissInputModal() {
+        viewController?.dismiss(animated: true, completion: nil)
+        guard let presentationController = viewController?.presentationController else {
+            return
+        }
+        viewController?.presentationController?.delegate?.presentationControllerDidDismiss?(presentationController)
+    }
 }


### PR DESCRIPTION
カレンダー画面からモーダルを閉じたときにデータがリストに反映されていない問題が起こっていた。
``UIAdaptivePresentationControllerDelegate``でmモーダルを閉じたときのイベントをキャッチしようとしたが、dismissを読んで閉じた時にはデリゲートは呼ばれない仕様だったので明示的に読んだ。イベントをキャッチしたところで最新のデータを取りに行くようにしている