### PR TITLE
カレンダータップ時にダイアログを出さないようにする

### DIFF
--- a/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -17,6 +17,7 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: Asset.pen.image, style: .plain, target: self, action: #selector(didTapRegisterButton(_:)))
         navigationItem.title = L10n.PatienceCalendarViewController.NavigationItem.title
         view.backgroundColor = .white
         calendar.translatesAutoresizingMaskIntoConstraints = false
@@ -74,19 +75,7 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
         return view
     }()
 
-    private lazy var alert: UIAlertController = {
-        let alert = UIAlertController(title: L10n.PatienceCalendarViewController.Alert.alertTitle, message: L10n.PatienceCalendarViewController.Alert.alertMessage, preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: L10n.PatienceCalendarViewController.Alert.CancelAction.title, style: .cancel)
-        let registerAction = UIAlertAction(title: L10n.PatienceCalendarViewController.Alert.RegisterAction.title, style: .default) { [weak self]_ in
-            self?.didTapRegisterButton()
-        }
-
-        alert.addAction(cancelAction)
-        alert.addAction(registerAction)
-        return alert
-    }()
-
-    private func didTapRegisterButton() {
+    @objc private func didTapRegisterButton(_ sender: UIBarButtonItem) {
         presenter.didTapRegisterButton(date: date)
     }
 
@@ -134,7 +123,6 @@ extension PatienceCalenderViewController: FSCalendarDelegate, FSCalendarDataSour
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         self.date = DateUtils.getStartDay(date: date)
         recordListHeaderView.title = DateUtils.stringFromDate(date: date, format: DateUtils.dateFormatJapanese)
-        present(alert, animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
close #44 
カレンダーの日付タップ時にいちいちダイアログが出るのがいまいちだったので日付タップ時には対応する日付のデータの表示のみに抑え、データの登録はナビゲーションアイテムをタッチした時に行うようにする。
なのでナビゲーションアイテムにアイコンを追加した
![Simulator Screen Shot - iPhone 12 Pro Max - 2021-05-23 at 22 17 33](https://user-images.githubusercontent.com/63186144/119262023-b1020700-bc14-11eb-93da-2d39bcdfd009.png)
