### PR TITLE
ダークモードの際の表示のバグを修正

### DIFF
--- a/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
@@ -58,6 +58,7 @@ class PatienceAnalyzeViewController: UIViewController, PatienceAnalyzeView {
         monthLabel.font = UIFont.systemFont(ofSize: 20)
         monthLabel.text = L10n.PatienceAnalyzeViewController.MonthLabel.text
         monthLabel.setContentHuggingPriority(.required, for: .horizontal)
+        monthLabel.textColor = UIColor.black
         monthSelectView.addSubview(monthLabel)
 
         NSLayoutConstraint.activate([

--- a/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
@@ -108,6 +108,7 @@ class PatienceAnalyzeViewController: UIViewController, PatienceAnalyzeView {
 
     private lazy var recordsView: UITableView = {
         let view = UITableView()
+        view.backgroundColor = .white
         view.register(RecordCell.self, forCellReuseIdentifier: RecordCell.reuseIdentifer)
         view.delegate = self
         view.dataSource = self

--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/YearAndMonthDateTextField.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/YearAndMonthDateTextField.swift
@@ -26,6 +26,7 @@ class YearAndMonthDateTextField: PatienceTextField {
         layer.cornerRadius = 4
         UIFont.boldSystemFont(ofSize: 20)
         backgroundColor = UIColor(hex: "F0E68C")
+        textColor = UIColor.black
         textAlignment = .center
 
         let pickerView = UIPickerView()

--- a/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/PatientMoney/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -75,6 +75,7 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
 
     private lazy var recordsView: UITableView = {
         let view = UITableView()
+        view.backgroundColor = .white
         view.register(RecordCell.self, forCellReuseIdentifier: RecordCell.reuseIdentifer)
         view.delegate = self
         view.dataSource = self

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/CategoriesView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/CategoriesView.swift
@@ -52,7 +52,7 @@ class CategoriesView: UIView {
 
     private lazy var categoriesView: UICollectionView = {
         let view = HeightSelfSizingCollectionView(frame: frame, collectionViewLayout: categoriesViewLayout)
-        view.backgroundColor = .clear
+        view.backgroundColor = .white
         view.delegate = self
         view.dataSource = self
         view.register(CategoryCell.self, forCellWithReuseIdentifier: CategoryCell.reuseIdentifer)

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/DateView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/DateView.swift
@@ -28,6 +28,7 @@ class DateView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.DateView.title
         titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
+        titleLabel.textColor = UIColor.black
         addSubview(titleLabel)
 
         dateTextField.translatesAutoresizingMaskIntoConstraints = false
@@ -36,6 +37,7 @@ class DateView: UIView {
         dateTextField.textInsets = UIEdgeInsets(top: 5, left: 20, bottom: 5, right: 20)
         dateTextField.font = UIFont.boldSystemFont(ofSize: 20)
         dateTextField.layer.cornerRadius = 4
+        dateTextField.textColor = UIColor.black
         addSubview(dateTextField)
 
         datePicker.datePickerMode = .date

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/MemoView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/MemoView.swift
@@ -27,6 +27,7 @@ class MemoView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
         titleLabel.text = L10n.MemoView.title
+        titleLabel.textColor = UIColor.black
         addSubview(titleLabel)
 
         memoTextView.translatesAutoresizingMaskIntoConstraints = false
@@ -36,6 +37,7 @@ class MemoView: UIView {
         memoTextView.textContainerInset = UIEdgeInsets(top: 5, left: 20, bottom: 5, right: 20)
         memoTextView.text = L10n.MemoView.MemoTextView.text
         memoTextView.isScrollEnabled = false
+        memoTextView.textColor = UIColor.black
         addSubview(memoTextView)
 
         memoTextView.inputAccessoryView = keyboardToolbar

--- a/PatientMoney/Module/PatienceRegister/View/ViewComponent/MoneyView.swift
+++ b/PatientMoney/Module/PatienceRegister/View/ViewComponent/MoneyView.swift
@@ -28,6 +28,7 @@ class MoneyView: UIView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.MoneyView.title
         titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
+        titleLabel.textColor = UIColor.black
         addSubview(titleLabel)
 
         moneyTextField.translatesAutoresizingMaskIntoConstraints = false
@@ -38,6 +39,8 @@ class MoneyView: UIView {
         moneyTextField.font = UIFont.boldSystemFont(ofSize: 20)
         moneyTextField.layer.cornerRadius = 4
         moneyTextField.keyboardType = .numberPad
+        moneyTextField.textColor = UIColor.black
+        moneyTextField.text = "0"
         addSubview(moneyTextField)
 
         moneyTextField.inputAccessoryView = keyboardToolbar
@@ -45,6 +48,7 @@ class MoneyView: UIView {
         yenLabel.translatesAutoresizingMaskIntoConstraints = false
         yenLabel.text = L10n.MoneyView.YenLabel.text
         yenLabel.font = UIFont.systemFont(ofSize: 14)
+        yenLabel.textColor = UIColor.black
         addSubview(yenLabel)
 
         NSLayoutConstraint.activate([

--- a/PatientMoney/ViewComponent/TableViewCell/RecordCell.swift
+++ b/PatientMoney/ViewComponent/TableViewCell/RecordCell.swift
@@ -26,13 +26,17 @@ class RecordCell: UITableViewCell {
     }
 
     private func construct() {
+        backgroundColor = .white
+
         icon.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(icon)
 
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.textColor = UIColor.black
         contentView.addSubview(titleLabel)
 
         moneyLabel.translatesAutoresizingMaskIntoConstraints = false
+        moneyLabel.textColor = UIColor.black
         contentView.addSubview(moneyLabel)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
ラベルなどのテキストカラーをシステムが自動決定するようにしていたためダークモードの際に見えにくくなるバグがあった。
明示的にデフォルトの色を指定することでダークモードの際にも表示の色が崩れないようにした