### PR TITLE
PatienceAnalyzeContractnの実装

### DIFF
--- a/PatientMoney/Data/DataStore/PatienceDataStore.swift
+++ b/PatientMoney/Data/DataStore/PatienceDataStore.swift
@@ -4,7 +4,6 @@ import Foundation
 import RxSwift
 
 class PatienceDataStore: PatienceRepository {
-    
     func registerPatienceData(data: [String: Any]) -> Single<Error?> {
         Single.create { [weak self] observer -> Disposable in
             guard let self = self else { return Disposables.create() }
@@ -61,10 +60,6 @@ class PatienceDataStore: PatienceRepository {
             }
             return Disposables.create()
         }
-    }
-    
-    func fetchPatienceData(date: Timestamp) -> Single<[PatienceEntity]> {
-        
     }
 
     func updatePatienceData(id: String, record: [String: Any]) -> Single<Error?> {

--- a/PatientMoney/Data/DataStore/PatienceDataStore.swift
+++ b/PatientMoney/Data/DataStore/PatienceDataStore.swift
@@ -4,6 +4,7 @@ import Foundation
 import RxSwift
 
 class PatienceDataStore: PatienceRepository {
+    
     func registerPatienceData(data: [String: Any]) -> Single<Error?> {
         Single.create { [weak self] observer -> Disposable in
             guard let self = self else { return Disposables.create() }
@@ -39,9 +40,11 @@ class PatienceDataStore: PatienceRepository {
         }
     }
 
-    func fetchPatienceData(startTimestamp: Timestamp, endTimestamp: Timestamp) -> Single<[PatienceEntity]> {
+    func fetchPatienceData(startDate: Date, endDate: Date) -> Single<[PatienceEntity]> {
         Single<[PatienceEntity]>.create { [weak self] observer ->Disposable in
             guard let self = self else { return Disposables.create() }
+            let startTimestamp = Timestamp(date: startDate)
+            let endTimestamp = Timestamp(date: endDate)
             let query = self.firestoreCollectionReference
                 .whereField("UID", isEqualTo: FirebaseAuthManeger.shared.uid)
                 .whereField("Date", isGreaterThanOrEqualTo: startTimestamp)
@@ -58,6 +61,10 @@ class PatienceDataStore: PatienceRepository {
             }
             return Disposables.create()
         }
+    }
+    
+    func fetchPatienceData(date: Timestamp) -> Single<[PatienceEntity]> {
+        
     }
 
     func updatePatienceData(id: String, record: [String: Any]) -> Single<Error?> {

--- a/PatientMoney/Module/PatienceAnalyze/Interactor/PatienceAnalyzeInteractor.swift
+++ b/PatientMoney/Module/PatienceAnalyze/Interactor/PatienceAnalyzeInteractor.swift
@@ -2,26 +2,24 @@ import FirebaseFirestore.FIRTimestamp
 import Foundation
 import RxSwift
 
-class PatienceAnalyzeInteractor: PatienceAnalyzeUsecase {
-    var repository: PatienceRepository!
-
-    var output: PatienceAnalyzeOutput?
-
-    func fetchDataFromMonth(year: Int, month: Int) {
-        let startDate = PaticuralDayFetcher.getBeginningMonth(year: year, month: month)
-        let endDate = PaticuralDayFetcher.getEndMonth(year: year, month: month)
-        let startTimestamp = Timestamp(date: startDate)
-        let endTimestamp = Timestamp(date: endDate)
-        repository.fetchPatienceData(startTimestamp: startTimestamp, endTimestamp: endTimestamp).subscribe { [weak self]observer in
-            switch observer {
-            case .success(let records):
-                self?.output?.outputFetchRecords(records: records)
-
-            case .failure(_):
-                self?.output?.outputError()
-            }
-        }.disposed(by: dispose)
-    }
-
-    private let dispose = DisposeBag()
-}
+//class PatienceAnalyzeInteractor: PatienceAnalyzeUsecase {
+//    var repository: PatienceRepository!
+//
+//    var output: PatienceAnalyzeOutput?
+//
+//    func fetchDataFromMonth(year: Int, month: Int) {
+//        let startDate = PaticuralDayFetcher.getBeginningMonth(year: year, month: month)
+//        let endDate = PaticuralDayFetcher.getEndMonth(year: year, month: month)
+//        repository.fetchPatienceData(startDate: startDate, endDate: endDate).subscribe { [weak self]observer in
+//            switch observer {
+//            case .success(let records):
+//                self?.output?.outputFetchRecords(records: records)
+//
+//            case .failure(_):
+//                self?.output?.outputError()
+//            }
+//        }.disposed(by: dispose)
+//    }
+//
+//    private let dispose = DisposeBag()
+//}

--- a/PatientMoney/Module/PatienceAnalyze/PatienceAnalyzeContract.swift
+++ b/PatientMoney/Module/PatienceAnalyze/PatienceAnalyzeContract.swift
@@ -6,22 +6,22 @@ protocol PatienceAnalyzeUsecase: AnyObject {
 
     var output: PatienceAnalyzeOutput? { get }
 
-    /// 入力された年月のデータを取得する
+    /// 指定年月のデータを取得する
     /// - parameter year:年
     /// - parameter month:月
     func fetchDataFromMonth(year: Int, month: Int)
+
+    /// 指定日時のデータを取得する
+    /// - parameter date:日付
+    func fetchDataFromDate(date: Date)
 }
 
 protocol PatienceAnalyzeView: AnyObject {
     var presentation: PatienceAnalyzePresentation! { get }
 
-    /// 記録を更新する
+    /// チャートを更新する
     /// - parameter records:記録
-    func updateRecords(records: [PatienceEntity])
-
-    /// 合計金額を更新する
-    /// - parameter sumMoney:合計金額
-    func updateSumMoney(sumMoney: Int)
+    func updateCharts(records: [PatienceChartDataModel])
 
     /// エラーを表示する
     /// - parameter message:エラーメッセージ
@@ -33,7 +33,8 @@ protocol PatienceAnalyzePresentation: AnyObject {
     var view: PatienceAnalyzeView? { get }
 
     /// 日付が変更された
-    func didSelectMonth(year: Int, month: Int)
+    /// - parameter date:選択されている日付
+    func didChangeDate(date: DateForTractableDay)
 }
 
 protocol PatienceAnalyzeOutput {

--- a/PatientMoney/Module/PatienceAnalyze/Presenter/PatienceAnalyzePresenter.swift
+++ b/PatientMoney/Module/PatienceAnalyze/Presenter/PatienceAnalyzePresenter.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-class PatienceAnalyzePresenter: PatienceAnalyzePresentation, PatienceAnalyzeOutput {
-    // MARK: PatienceAnalyzePresentation
-    var usecase: PatienceAnalyzeUsecase!
-
-    var view: PatienceAnalyzeView?
-
-    func didSelectMonth(year: Int, month: Int) {
-        usecase.fetchDataFromMonth(year: year, month: month)
-    }
-
-    // MARK: PatienceAnalyzeOutput
-    func outputFetchRecords(records: [PatienceEntity]) {
-        view?.updateRecords(records: records)
-        var sumMoney = 0
-        records.forEach {
-            sumMoney += $0.money
-        }
-        view?.updateSumMoney(sumMoney: sumMoney)
-    }
-
-    func outputError() {
-        view?.showError(message: L10n.PatienceAnalyzePresenter.StatusNotification.Error.title)
-    }
-}
+//class PatienceAnalyzePresenter: PatienceAnalyzePresentation, PatienceAnalyzeOutput {
+//    // MARK: PatienceAnalyzePresentation
+//    var usecase: PatienceAnalyzeUsecase!
+//
+//    var view: PatienceAnalyzeView?
+//
+//    func didSelectMonth(year: Int, month: Int) {
+//        usecase.fetchDataFromMonth(year: year, month: month)
+//    }
+//
+//    // MARK: PatienceAnalyzeOutput
+//    func outputFetchRecords(records: [PatienceEntity]) {
+//        view?.updateRecords(records: records)
+//        var sumMoney = 0
+//        records.forEach {
+//            sumMoney += $0.money
+//        }
+//        view?.updateSumMoney(sumMoney: sumMoney)
+//    }
+//
+//    func outputError() {
+//        view?.showError(message: L10n.PatienceAnalyzePresenter.StatusNotification.Error.title)
+//    }
+//}

--- a/PatientMoney/Module/PatienceAnalyze/Router/PatienceAnalyzeRouter.swift
+++ b/PatientMoney/Module/PatienceAnalyze/Router/PatienceAnalyzeRouter.swift
@@ -1,19 +1,19 @@
-import Foundation
-import UIKit.UIViewController
-
-class PatienceAnalyzeRouter {
-    static func assembleModule() -> UIViewController {
-        let viewController = PatienceAnalyzeViewController()
-        let presenter = PatienceAnalyzePresenter()
-        let interactor = PatienceAnalyzeInteractor()
-        let dataStore = PatienceDataStore()
-
-        presenter.usecase = interactor
-        presenter.view = viewController
-        interactor.output = presenter
-        interactor.repository = dataStore
-        viewController.presentation = presenter
-
-        return viewController
-    }
-}
+//import Foundation
+//import UIKit.UIViewController
+//
+//class PatienceAnalyzeRouter {
+//    static func assembleModule() -> UIViewController {
+//        let viewController = PatienceAnalyzeViewController()
+//        let presenter = PatienceAnalyzePresenter()
+//        let interactor = PatienceAnalyzeInteractor()
+//        let dataStore = PatienceDataStore()
+//
+//        presenter.usecase = interactor
+//        //presenter.view = viewController
+//        interactor.output = presenter
+//        interactor.repository = dataStore
+//        //viewController.presentation = presenter
+//
+//        return viewController
+//    }
+//}

--- a/PatientMoney/Module/PatienceCalendar/Interactor/PatienceCalendarInteractor.swift
+++ b/PatientMoney/Module/PatienceCalendar/Interactor/PatienceCalendarInteractor.swift
@@ -24,9 +24,7 @@ class PatienceCalendarInteractor: PatienceCalendarUsecase {
     func fetchDataFromMonth(year: Int, month: Int) {
         let startDate = PaticuralDayFetcher.getBeginningMonth(year: year, month: month)
         let endDate = PaticuralDayFetcher.getEndMonth(year: year, month: month)
-        let startTimestamp = Timestamp(date: startDate)
-        let endTimestamp = Timestamp(date: endDate)
-        repository.fetchPatienceData(startTimestamp: startTimestamp, endTimestamp: endTimestamp).subscribe { [weak self]observer in
+        repository.fetchPatienceData(startDate: startDate, endDate: endDate).subscribe { [weak self]observer in
             switch observer {
             case .success(let records):
                 self?.output?.outputFetchRecordsPerMonth(records: records)

--- a/PatientMoney/Module/PatienceInput/PatienceInputContract.swift
+++ b/PatientMoney/Module/PatienceInput/PatienceInputContract.swift
@@ -93,7 +93,11 @@ protocol PatienceRepository {
     /// 指定期間のデータをフェッチする
     /// - parameter startDate:開始日
     /// - parameter endDate:終了日
-    func fetchPatienceData(startTimestamp: Timestamp, endTimestamp: Timestamp) -> Single<[PatienceEntity]>
+    func fetchPatienceData(startDate: Date, endDate: Date) -> Single<[PatienceEntity]>
+
+    /// 指定日時のデータをフェッチする
+    /// - parameter dateTimestamp:日付タイムスタンプ
+    func fetchPatienceData(date: Timestamp) -> Single<[PatienceEntity]>
 
     /// データをupdateする
     /// - parameter id:ドキュメントID

--- a/PatientMoney/Module/PatienceInput/PatienceInputContract.swift
+++ b/PatientMoney/Module/PatienceInput/PatienceInputContract.swift
@@ -95,10 +95,6 @@ protocol PatienceRepository {
     /// - parameter endDate:終了日
     func fetchPatienceData(startDate: Date, endDate: Date) -> Single<[PatienceEntity]>
 
-    /// 指定日時のデータをフェッチする
-    /// - parameter dateTimestamp:日付タイムスタンプ
-    func fetchPatienceData(date: Timestamp) -> Single<[PatienceEntity]>
-
     /// データをupdateする
     /// - parameter id:ドキュメントID
     /// - parameter record:データレコード


### PR DESCRIPTION
PatienceAnalyzeContractを実装した。
特定期間のデータを取得するInteractorメソッド内で、DataStoreにFirestampに変換した日付を渡していたが、InteractorがRepository以下の情報は知るべきではないため、ただ単純に日付を渡すのみにした。