### PR TITLE
日付関連のバグを修正

### DIFF
--- a/PatientMoney.xcodeproj/project.pbxproj
+++ b/PatientMoney.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		3D9773452640496600419E8A /* RxBlocking.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DEB539E263FF784002A2166 /* RxBlocking.xcframework */; };
 		3D9773482640497000419E8A /* RxTest.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DEB53A2263FF784002A2166 /* RxTest.xcframework */; };
 		3D9FEC2226679755008A77FC /* PatienceAnalyzeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC2126679755008A77FC /* PatienceAnalyzeViewController.swift */; };
-		3D9FEC2C2667A95D008A77FC /* SelectableDatePickStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC2B2667A95D008A77FC /* SelectableDatePickStyleTextField.swift */; };
+		3D9FEC2C2667A95D008A77FC /* SelectableDateStylePickerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC2B2667A95D008A77FC /* SelectableDateStylePickerTextField.swift */; };
 		3D9FEC2E2667FB1A008A77FC /* PatienceAnalyzeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC2D2667FB1A008A77FC /* PatienceAnalyzeInteractor.swift */; };
 		3D9FEC302667FB37008A77FC /* PatienceAnalyzeContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC2F2667FB37008A77FC /* PatienceAnalyzeContract.swift */; };
 		3D9FEC3226680174008A77FC /* PatienceAnalyzePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9FEC3126680174008A77FC /* PatienceAnalyzePresenter.swift */; };
@@ -220,7 +220,7 @@
 		3D6DFFEF263555F200C30DD1 /* PromisesObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromisesObjC.framework; path = Carthage/Build/iOS/PromisesObjC.framework; sourceTree = "<group>"; };
 		3D6DFFF0263555F200C30DD1 /* nanopb.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = nanopb.framework; path = Carthage/Build/iOS/nanopb.framework; sourceTree = "<group>"; };
 		3D9FEC2126679755008A77FC /* PatienceAnalyzeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceAnalyzeViewController.swift; sourceTree = "<group>"; };
-		3D9FEC2B2667A95D008A77FC /* SelectableDatePickStyleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableDatePickStyleTextField.swift; sourceTree = "<group>"; };
+		3D9FEC2B2667A95D008A77FC /* SelectableDateStylePickerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableDateStylePickerTextField.swift; sourceTree = "<group>"; };
 		3D9FEC2D2667FB1A008A77FC /* PatienceAnalyzeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceAnalyzeInteractor.swift; sourceTree = "<group>"; };
 		3D9FEC2F2667FB37008A77FC /* PatienceAnalyzeContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceAnalyzeContract.swift; sourceTree = "<group>"; };
 		3D9FEC3126680174008A77FC /* PatienceAnalyzePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceAnalyzePresenter.swift; sourceTree = "<group>"; };
@@ -612,7 +612,7 @@
 		3D9FEC2A2667A948008A77FC /* ViewComponent */ = {
 			isa = PBXGroup;
 			children = (
-				3D9FEC2B2667A95D008A77FC /* SelectableDatePickStyleTextField.swift */,
+				3D9FEC2B2667A95D008A77FC /* SelectableDateStylePickerTextField.swift */,
 				3DCEB8C1267C7A7000EDD973 /* PatienceChartsView.swift */,
 				3D55A05B267CEADE006422BC /* DateSelectStyleCheckView.swift */,
 				3D55A05D267DBE69006422BC /* CheckBox.swift */,
@@ -980,7 +980,7 @@
 				3DE103CC2638360800F724B8 /* Asset.swift in Sources */,
 				3DEE39A0264112C4005D3EB0 /* PatienceEntity.swift in Sources */,
 				3DCEB8AB267B1B4400EDD973 /* PatienceUpdatePresenter.swift in Sources */,
-				3D9FEC2C2667A95D008A77FC /* SelectableDatePickStyleTextField.swift in Sources */,
+				3D9FEC2C2667A95D008A77FC /* SelectableDateStylePickerTextField.swift in Sources */,
 				3D61B4E2264EDA2F001C74B6 /* RecordListHeaderView.swift in Sources */,
 				3D6B0FE7263D85E0009D21A1 /* DateView.swift in Sources */,
 				3DE10408263B976700F724B8 /* AuthContract.swift in Sources */,

--- a/PatientMoney/Data/DataStore/PatienceDataStore.swift
+++ b/PatientMoney/Data/DataStore/PatienceDataStore.swift
@@ -95,7 +95,7 @@ class PatienceDataStore: PatienceRepository {
     private func createPatienceRecord(documents: [QueryDocumentSnapshot]) -> [PatienceEntity] {
         documents.map {
             PatienceEntity(documentID: $0.documentID,
-                           date: ($0.data()["Date"] as? Date) ?? Date() ,
+                           date: (($0.data()["Date"] as? Timestamp)?.dateValue()) ?? Date() ,
                            memo: ($0.data()["Memo"] as? String) ?? "",
                            money: ($0.data()["Money"] as? Int) ?? 0,
                            categoryTitle: ( $0.data()["Category"] as? String) ?? ""  )

--- a/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
@@ -17,7 +17,7 @@ class PatienceAnalyzeViewController: UIViewController, PatienceAnalyzeView {
         view.addSubview(vstack)
 
         vstack.addArrangedSubview(textField)
-        textField.selectedAction = {[weak self] date in
+        textField.dateChangeAction = {[weak self] date in
             guard let self = self else { return }
             self.presentation.didChangeDate(dateModel: date, isSingleDaySelect: !self.checkView.isChecked)
         }

--- a/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/PatienceAnalyzeViewController.swift
@@ -43,7 +43,7 @@ class PatienceAnalyzeViewController: UIViewController, PatienceAnalyzeView {
 
     private let vstack = UIStackView()
 
-    private let textField = SelectableDatePickStyleTextField()
+    private let textField = SelectableDateStylePickerTextField()
 
     private let chart = PatienceChartsView()
 

--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
@@ -16,7 +16,7 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         }
     }
 
-    var selectedAction:((_ date: DateForTractableDay) -> Void)?
+    var dateChangeAction:((_ date: DateForTractableDay) -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -64,6 +64,7 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         } else {
             inputView = yearAndMonthPickerView
         }
+        dateChangeAction?(selectedDate)
     }
 
     private lazy var years: [Int] = { (2000...currentYear).reversed().map { $0 } }()
@@ -97,7 +98,7 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         }
         text = selectedDate.dateString
         endEditing(true)
-        selectedAction?(selectedDate)
+        dateChangeAction?(selectedDate)
     }
 
     // 入力カーソル非表示

--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
@@ -29,13 +29,6 @@ class SelectableDatePickStyleTextField: PatienceTextField {
     }
 
     private func construct() {
-        setUpYearAndMonthPickerView()
-        setUpDatePickerView()
-        updatePickStyle()
-    }
-
-    // TODO: 責務ごちゃごちゃ
-    private func setUpYearAndMonthPickerView() {
         font = UIFont.boldSystemFont(ofSize: 20)
         text = DateAndStringConverter.stringFromDate(date: Date(), format: "yyyy年　M月")
         selectedDate.isIncludeDate = isSingleDaySelect
@@ -45,11 +38,16 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         textColor = UIColor.black
         textAlignment = .center
 
+        setUpYearAndMonthPickerView()
+        setUpDatePickerView()
+        updatePickStyle()
+    }
+
+    private func setUpYearAndMonthPickerView() {
         yearAndMonthPickerView.delegate = self
         yearAndMonthPickerView.dataSource = self
         yearAndMonthPickerView.selectRow(DateForTractableDay().year - currentYear, inComponent: 0, animated: true)
         yearAndMonthPickerView.selectRow(DateForTractableDay().month - 1, inComponent: 1, animated: true)
-        inputView = yearAndMonthPickerView
         inputAccessoryView = keyboardToolbar
     }
 
@@ -100,6 +98,21 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         text = selectedDate.dateString
         endEditing(true)
         selectedAction?(selectedDate)
+    }
+
+    // 入力カーソル非表示
+    override func caretRect(for position: UITextPosition) -> CGRect {
+        CGRect.zero
+    }
+
+    // 範囲選択カーソル非表示
+    override func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
+        []
+    }
+
+    // コピー・ペースト・選択等のメニュー非表示
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        false
     }
 }
 

--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDatePickStyleTextField.swift
@@ -34,6 +34,7 @@ class SelectableDatePickStyleTextField: PatienceTextField {
         updatePickStyle()
     }
 
+    // TODO: 責務ごちゃごちゃ
     private func setUpYearAndMonthPickerView() {
         font = UIFont.boldSystemFont(ofSize: 20)
         text = DateAndStringConverter.stringFromDate(date: Date(), format: "yyyy年　M月")
@@ -46,6 +47,8 @@ class SelectableDatePickStyleTextField: PatienceTextField {
 
         yearAndMonthPickerView.delegate = self
         yearAndMonthPickerView.dataSource = self
+        yearAndMonthPickerView.selectRow(DateForTractableDay().year - currentYear, inComponent: 0, animated: true)
+        yearAndMonthPickerView.selectRow(DateForTractableDay().month - 1, inComponent: 1, animated: true)
         inputView = yearAndMonthPickerView
         inputAccessoryView = keyboardToolbar
     }

--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDateStylePickerTextField.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/SelectableDateStylePickerTextField.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// 日付のピック方法を選べるdatePickerTextField
-class SelectableDatePickStyleTextField: PatienceTextField {
+class SelectableDateStylePickerTextField: PatienceTextField {
     var selectedDate = DateForTractableDay() {
         didSet {
             text = selectedDate.dateString
@@ -118,7 +118,7 @@ class SelectableDatePickStyleTextField: PatienceTextField {
 }
 
 // MARK: - UIPickerViewDelegate,UIPickerViewDataSource
-extension SelectableDatePickStyleTextField: UIPickerViewDelegate, UIPickerViewDataSource {
+extension SelectableDateStylePickerTextField: UIPickerViewDelegate, UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         2
     }

--- a/PatientMoney/Module/PatienceInput/View/ViewComponent/DateView.swift
+++ b/PatientMoney/Module/PatienceInput/View/ViewComponent/DateView.swift
@@ -49,7 +49,7 @@ class DateView: UIView {
 
     private let titleLabel = UILabel()
 
-    private let dateTextField = SelectableDatePickStyleTextField()
+    private let dateTextField = SelectableDateStylePickerTextField()
 }
 
 extension DateView: UITextFieldDelegate {

--- a/PatientMoney/Util/DateUtil.swift
+++ b/PatientMoney/Util/DateUtil.swift
@@ -72,9 +72,9 @@ struct DateForTractableDay {
         }
         set {
             let current = Calendar.current
-            year = current.component(.year, from: date)
-            month = current.component(.month, from: date)
-            day = isIncludeDate ? current.component(.day, from: date):1
+            year = current.component(.year, from: newValue)
+            month = current.component(.month, from: newValue)
+            day = isIncludeDate ? current.component(.day, from: newValue):1
         }
     }
     var isIncludeDate = true {

--- a/PatientMoneyTests/SelectableDatePickStyleTextFieldTest.swift
+++ b/PatientMoneyTests/SelectableDatePickStyleTextFieldTest.swift
@@ -27,13 +27,13 @@ class SelectableDatePickStyleTextFieldTest: XCTestCase {
     }
 
     func testCorrectTextDisplayWhenIsSingleSelect() {
-        let dateTextField = SelectableDatePickStyleTextField()
+        let dateTextField = SelectableDateStylePickerTextField()
         dateTextField.selectedDate.date = date
         XCTAssertEqual(dateTextField.text, "2000年02月28日")
     }
 
     func testCorrectTextDisplayWhenNotIsSingleSelect() {
-        let dateTextField = SelectableDatePickStyleTextField()
+        let dateTextField = SelectableDateStylePickerTextField()
         dateTextField.isSingleDaySelect = false
         dateTextField.selectedDate.date = date
         XCTAssertEqual(dateTextField.text, "2000年02月")

--- a/PatientMoneyTests/SelectableDatePickStyleTextFieldTest.swift
+++ b/PatientMoneyTests/SelectableDatePickStyleTextFieldTest.swift
@@ -28,14 +28,14 @@ class SelectableDatePickStyleTextFieldTest: XCTestCase {
 
     func testCorrectTextDisplayWhenIsSingleSelect() {
         let dateTextField = SelectableDatePickStyleTextField()
-        dateTextField.selectedDate.injectDate(date: date)
+        dateTextField.selectedDate.date = date
         XCTAssertEqual(dateTextField.text, "2000年02月28日")
     }
 
     func testCorrectTextDisplayWhenNotIsSingleSelect() {
         let dateTextField = SelectableDatePickStyleTextField()
         dateTextField.isSingleDaySelect = false
-        dateTextField.selectedDate.injectDate(date: date)
+        dateTextField.selectedDate.date = date
         XCTAssertEqual(dateTextField.text, "2000年02月")
     }
 


### PR DESCRIPTION
- 変更点
    -  DateForTractableaDayクラスのdateプロパティにアクセスしてもデフォルトの日付のままであったので、dateプロパティのセッターでnewValueを使うように変更した。
    -  日付ピッカーの切り替え次にデータをリクエストするようにした。
    -  SelectableDatePickStyleTextFieldを編集不可にした。
    -  SelectableDateStylePickerTextFieldの年月のデフォルト値をその日の年月にしておく。
    -  firestoreから取ってきた日付のデータをDate型にキャストすると失敗するので、TimeStamp型にキャストした後にDate型にするようにする。
