### PR TITLE
角丸のUIのバグを修正

### DIFF
--- a/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/CheckBox.swift
+++ b/PatientMoney/Module/PatienceAnalyze/View/ViewComponent/CheckBox.swift
@@ -27,8 +27,6 @@ class CheckBox: UIControl {
         iconLabel.translatesAutoresizingMaskIntoConstraints = false
         iconLabel.attributedText = NSAttributedString.icon(FontAwesome.Icon.check, size: 20)
         iconLabel.textAlignment = .center
-        iconLabel.layer.cornerRadius = 4
-        iconLabel.clipsToBounds = true
         addSubview(iconLabel)
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: 30),
@@ -44,7 +42,6 @@ class CheckBox: UIControl {
 
     @objc private func touchAction(_ sender: UIControl) {
         isOn.toggle()
-        backgroundColor = .red
         checkBoxSelectedAction?(isOn)
     }
 

--- a/PatientMoney/Module/PatienceInput/View/ViewComponent/CategoryCell.swift
+++ b/PatientMoney/Module/PatienceInput/View/ViewComponent/CategoryCell.swift
@@ -61,6 +61,7 @@ class CategoryCell: UICollectionViewCell {
 
         layer.borderWidth = 1
         layer.cornerRadius = 4
+        clipsToBounds = true
 
         iconLabel.translatesAutoresizingMaskIntoConstraints = false
         iconLabel.textAlignment = .center


### PR DESCRIPTION
下記のように分析画面のチェックボックスの角丸と登録画面のカテゴリーの角丸の表示がおかしかったので修正した。
![IMG_7838 2](https://user-images.githubusercontent.com/63186144/123951675-04b7fb00-d9e0-11eb-9da9-d2b968cc000b.PNG)
![IMG_7836](https://user-images.githubusercontent.com/63186144/123951713-0e416300-d9e0-11eb-9c06-fdd601cb3037.PNG)

修正後
![IMG_7845](https://user-images.githubusercontent.com/63186144/123951854-3335d600-d9e0-11eb-8972-366f0bd6f445.PNG)
![IMG_7844](https://user-images.githubusercontent.com/63186144/123951871-38932080-d9e0-11eb-93f8-b27aabbd8938.PNG)
