### PR TITLE
Categoryのデータ構造を変更

### DIFF
--- a/saving/Module/PatienceAnalyze/View/ViewComponent/PatienceChartsView.swift
+++ b/saving/Module/PatienceAnalyze/View/ViewComponent/PatienceChartsView.swift
@@ -40,22 +40,22 @@ class PatienceChartsView: PieChartView {
         var hobbyMoney = 0
         records.forEach {record in
             switch record.categoryTilte {
-            case Category.categories[0].title:
+            case Category.allCases[0].title:
                 foodMoney += record.money
 
-            case Category.categories[1].title:
+            case Category.allCases[1].title:
                 transportMoney += record.money
 
-            case Category.categories[2].title:
+            case Category.allCases[2].title:
                 drinkMoney += record.money
 
-            case Category.categories[3].title:
+            case Category.allCases[3].title:
                 communicationMoney += record.money
 
-            case Category.categories[4].title:
+            case Category.allCases[4].title:
                 wearMoney += record.money
 
-            case Category.categories[5].title:
+            case Category.allCases[5].title:
                 hobbyMoney += record.money
 
             default:
@@ -63,12 +63,12 @@ class PatienceChartsView: PieChartView {
             }
         }
 
-        dataEntries.append(PieChartDataEntry(value: Double(foodMoney), label: Category.categories[0].title, data: Double(foodMoney)))
-        dataEntries.append(PieChartDataEntry(value: Double(transportMoney), label: Category.categories[1].title, data: Double(transportMoney)))
-        dataEntries.append(PieChartDataEntry(value: Double(drinkMoney), label: Category.categories[2].title, data: Double(drinkMoney)))
-        dataEntries.append(PieChartDataEntry(value: Double(communicationMoney), label: Category.categories[3].title, data: Double(communicationMoney)))
-        dataEntries.append(PieChartDataEntry(value: Double(wearMoney), label: Category.categories[4].title, data: Double(wearMoney)))
-        dataEntries.append(PieChartDataEntry(value: Double(hobbyMoney), label: Category.categories[5].title, data: Double(hobbyMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(foodMoney), label: Category.allCases[0].title, data: Double(foodMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(transportMoney), label: Category.allCases[1].title, data: Double(transportMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(drinkMoney), label: Category.allCases[2].title, data: Double(drinkMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(communicationMoney), label: Category.allCases[3].title, data: Double(communicationMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(wearMoney), label: Category.allCases[4].title, data: Double(wearMoney)))
+        dataEntries.append(PieChartDataEntry(value: Double(hobbyMoney), label: Category.allCases[5].title, data: Double(hobbyMoney)))
 
         let dataSet = PieChartDataSet(entries: dataEntries, label: L10n.PatienceChartsView.Charts.description)
         dataSet.valueTextColor = .black

--- a/saving/Module/PatienceCalendar/View/ViewComponents/RecordCell.swift
+++ b/saving/Module/PatienceCalendar/View/ViewComponents/RecordCell.swift
@@ -61,7 +61,7 @@ class RecordCell: UITableViewCell {
     private let moneyLabel = UILabel()
 
     private func updateValue() {
-        let category = Category.categories.filter {
+        let category = Category.allCases.filter {
             $0.title == categoryTitle
         }
         icon.attributedText = NSAttributedString.icon(category[0].icon, size: 20, style: .solid)

--- a/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
@@ -66,7 +66,7 @@ class CategoriesView: UIView {
 // MARK: CollectionViewDelegateMethod
 extension CategoriesView: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        Category.categories.count
+        Category.allCases.count
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
@@ -78,7 +78,7 @@ extension CategoriesView: UICollectionViewDelegate, UICollectionViewDataSource, 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         // swiftlint:disable:next force_cast
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CategoryCell.reuseIdentifer, for: indexPath) as! CategoryCell
-        let category = Category.categories[indexPath.item]
+        let category = Category.allCases[indexPath.item]
         cell.icon = category.icon
         cell.title = category.title
         cell.color = category.color
@@ -87,7 +87,7 @@ extension CategoriesView: UICollectionViewDelegate, UICollectionViewDataSource, 
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let category = Category.categories[indexPath.item]
+        let category = Category.allCases[indexPath.item]
         selectedCategoryTitle = category.title
         categoriesView.reloadData()
     }

--- a/saving/Util/Category.swift
+++ b/saving/Util/Category.swift
@@ -1,12 +1,76 @@
 import UIKit
 
-class Category {
-    static let categories:[(icon: FontAwesome.Icon, title: String, color: UIColor)] = [
-        (icon:.pizzaSlice, title:L10n.CategoryIcon.Title.pizzaSlice, UIColor(hex: "FFA500")),
-        (icon:.bus, title:L10n.CategoryIcon.Title.bus, UIColor(hex: "00BFFF")),
-        (icon:.beer, title:L10n.CategoryIcon.Title.beer, UIColor(hex: "FFFF00")),
-        (icon:.child, title:L10n.CategoryIcon.Title.child, UIColor(hex: "FFA07A")),
-        (icon:.tshirt, title:L10n.CategoryIcon.Title.tshirt, UIColor(hex: "425D69")),
-        (icon:.paintBrush, title:L10n.CategoryIcon.Title.paintBrush, UIColor(hex: "FF0000"))
-    ]
+enum Category: CaseIterable {
+    case pizzaSlice
+    case bus
+    case beer
+    case child
+    case tshirt
+    case paintBrusy
+
+    var icon: FontAwesome.Icon {
+        switch self {
+        case .pizzaSlice:
+            return .pizzaSlice
+
+        case .bus:
+            return .bus
+
+        case .beer:
+            return .beer
+
+        case .child:
+            return .child
+
+        case .tshirt:
+            return .tshirt
+
+        case .paintBrusy:
+            return .paintBrush
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .pizzaSlice:
+            return L10n.CategoryIcon.Title.pizzaSlice
+
+        case .bus:
+            return L10n.CategoryIcon.Title.bus
+
+        case .beer:
+            return L10n.CategoryIcon.Title.beer
+
+        case .child:
+            return L10n.CategoryIcon.Title.child
+
+        case .tshirt:
+            return L10n.CategoryIcon.Title.tshirt
+
+        case .paintBrusy:
+            return L10n.CategoryIcon.Title.paintBrush
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .pizzaSlice:
+            return UIColor(hex: "FFA500")
+
+        case .bus:
+            return UIColor(hex: "00BFFF")
+
+        case .beer:
+            return UIColor(hex: "FFFF00")
+
+        case .child:
+            return UIColor(hex: "FFA07A")
+
+        case .tshirt:
+            return UIColor(hex: "425D69")
+
+        case .paintBrusy:
+            return UIColor(hex: "FF0000")
+        }
+    }
 }


### PR DESCRIPTION
タプル型の配列でCategoryを扱っているが、enum の方が扱いやすいのでenumで使用するようにする。
総数を取得させたいため、CaseIterableに準拠させる。