### PR TITLE
登録画面の改善

### DIFF
--- a/saving.xcodeproj/project.pbxproj
+++ b/saving.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3D1EB49226D119140055CF6E /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1EB49126D119140055CF6E /* DateExtension.swift */; };
 		3D1EB49426D119CD0055CF6E /* TimeZoneExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1EB49326D119CD0055CF6E /* TimeZoneExtension.swift */; };
 		3D1EB49626D119E30055CF6E /* LocaleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1EB49526D119E30055CF6E /* LocaleExtension.swift */; };
+		3D1EB49A26D225FA0055CF6E /* PatienceInputViewComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1EB49926D225FA0055CF6E /* PatienceInputViewComponent.swift */; };
 		3D205C6326381C820058064C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3D205C6226381C820058064C /* Localizable.strings */; };
 		3D2A1E8126C685FF0013F247 /* APITargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2A1E8026C685FF0013F247 /* APITargetType.swift */; };
 		3D2A1E8326C687090013F247 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2A1E8226C687090013F247 /* APIClient.swift */; };
@@ -136,6 +137,7 @@
 		3D1EB49126D119140055CF6E /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		3D1EB49326D119CD0055CF6E /* TimeZoneExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneExtension.swift; sourceTree = "<group>"; };
 		3D1EB49526D119E30055CF6E /* LocaleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleExtension.swift; sourceTree = "<group>"; };
+		3D1EB49926D225FA0055CF6E /* PatienceInputViewComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatienceInputViewComponent.swift; sourceTree = "<group>"; };
 		3D205C6226381C820058064C /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		3D2A1E8026C685FF0013F247 /* APITargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITargetType.swift; sourceTree = "<group>"; };
 		3D2A1E8226C687090013F247 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				3D6B0FF5263E76AA009D21A1 /* MemoView.swift */,
 				3D6B0FFF263E94E1009D21A1 /* MoneyView.swift */,
 				3D6963DD2678D26100368810 /* CategoryCell.swift */,
+				3D1EB49926D225FA0055CF6E /* PatienceInputViewComponent.swift */,
 			);
 			path = ViewComponent;
 			sourceTree = "<group>";
@@ -895,6 +898,7 @@
 				3D3A3250263F2B9800077B6D /* PatienceInputRouter.swift in Sources */,
 				3DB5C5BD26CCE641005E3299 /* PatienceEntity.swift in Sources */,
 				3DEB53C826400B96002A2166 /* PatienceCalendarRouter.swift in Sources */,
+				3D1EB49A26D225FA0055CF6E /* PatienceInputViewComponent.swift in Sources */,
 				3D6963DE2678D26100368810 /* CategoryCell.swift in Sources */,
 				3D6B1000263E94E1009D21A1 /* MoneyView.swift in Sources */,
 				3D2A1E8126C685FF0013F247 /* APITargetType.swift in Sources */,

--- a/saving/API/Entity/PatienceEntity.swift
+++ b/saving/API/Entity/PatienceEntity.swift
@@ -3,7 +3,7 @@ import Foundation
 struct PatienceEntity: Decodable {
     let id: Int
     let registeredAt: Date
-    let memo: String
+    let memo: String?
     let money: Int
     let categoryTitle: String
 

--- a/saving/Data/DataStore/PatienceDataStore.swift
+++ b/saving/Data/DataStore/PatienceDataStore.swift
@@ -4,7 +4,7 @@ import RxSwift
 class PatienceDataStore: PatienceRepository {
     func registerPatienceData(record: PatienceEntity) -> Single<PatienceEntity> {
         Single.create { observer -> Disposable in
-            ApiClient.shared.request(CreatePatienceTargetType(registeredAt: record.registeredAt, money: record.money, memo: record.memo, categoryTitle: record.categoryTitle)) { result in
+            ApiClient.shared.request(CreatePatienceTargetType(registeredAt: record.registeredAt, money: record.money, memo: record.memo ?? "", categoryTitle: record.categoryTitle)) { result in
                 switch result {
                 case let .success(record):
                     observer(.success(record))

--- a/saving/Generated/Strings.swift
+++ b/saving/Generated/Strings.swift
@@ -139,7 +139,7 @@ internal enum L10n {
     internal static let title = L10n.tr("Localizable", "MemoView.title")
     internal enum MemoTextView {
       /// 未入力
-      internal static let placeHolder = L10n.tr("Localizable", "MemoView.MemoTextView.placeHolder")
+      internal static let placeholder = L10n.tr("Localizable", "MemoView.MemoTextView.placeholder")
     }
   }
 

--- a/saving/Generated/Strings.swift
+++ b/saving/Generated/Strings.swift
@@ -139,7 +139,7 @@ internal enum L10n {
     internal static let title = L10n.tr("Localizable", "MemoView.title")
     internal enum MemoTextView {
       /// 未入力
-      internal static let text = L10n.tr("Localizable", "MemoView.MemoTextView.text")
+      internal static let placeHolder = L10n.tr("Localizable", "MemoView.MemoTextView.placeHolder")
     }
   }
 

--- a/saving/Module/PatienceCalendar/View/ViewComponents/RecordCell.swift
+++ b/saving/Module/PatienceCalendar/View/ViewComponents/RecordCell.swift
@@ -4,7 +4,7 @@ class RecordCell: UITableViewCell {
     static let reuseIdentifer = "patience-record"
 
     /// カテゴリータイトル
-    var categoryTitle = L10n.CategoryIcon.Title.pizzaSlice {
+    var categoryTitle = Category.pizzaSlice.title {
         didSet {
             updateValue()
         }

--- a/saving/Module/PatienceInput/Router/PatienceInputRouter.swift
+++ b/saving/Module/PatienceInput/Router/PatienceInputRouter.swift
@@ -32,7 +32,7 @@ class PatienceInputRouter: PatienceInputWireframe {
         let router = PatienceInputRouter()
 
         registerView.dateRecord = record.registeredAt
-        registerView.memoRecord = record.memo
+        registerView.memoRecord = record.memo ?? ""
         registerView.moneyRecord = record.money
         registerView.categoryTitleRecord = record.categoryTitle
         presenter.id = record.id

--- a/saving/Module/PatienceInput/View/PatienceInputViewController.swift
+++ b/saving/Module/PatienceInput/View/PatienceInputViewController.swift
@@ -129,7 +129,7 @@ class PatienceInputViewController: UIViewController, PatienceInputView {
     private func resetData() {
         dateRecord = Date()
         moneyRecord = 0
-        memoRecord = L10n.MemoView.MemoTextView.text
+        memoRecord = L10n.MemoView.MemoTextView.placeHolder
         categoryTitleRecord = L10n.CategoryIcon.Title.pizzaSlice
     }
 

--- a/saving/Module/PatienceInput/View/PatienceInputViewController.swift
+++ b/saving/Module/PatienceInput/View/PatienceInputViewController.swift
@@ -127,10 +127,9 @@ class PatienceInputViewController: UIViewController, PatienceInputView {
     }()
 
     private func resetData() {
-        dateRecord = Date()
-        moneyRecord = 0
-        memoRecord = L10n.MemoView.MemoTextView.placeHolder
-        categoryTitleRecord = L10n.CategoryIcon.Title.pizzaSlice
+        subViews.forEach {
+            $0.resetView()
+        }
     }
 
     @objc private func inputButtonAction(_ :UIButton) {

--- a/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
@@ -4,7 +4,7 @@ import UIKit
 /// カテゴリーView
 class CategoriesView: PatienceInputViewComponent {
     /// 選択されたカテゴリータイトル
-    var selectedCategoryTitle: String = L10n.CategoryIcon.Title.pizzaSlice {
+    var selectedCategoryTitle: String = Category.pizzaSlice.title {
         didSet {
             categoriesView.reloadData()
         }

--- a/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/CategoriesView.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// カテゴリーView
-class CategoriesView: UIView {
+class CategoriesView: PatienceInputViewComponent {
     /// 選択されたカテゴリータイトル
     var selectedCategoryTitle: String = L10n.CategoryIcon.Title.pizzaSlice {
         didSet {
@@ -18,6 +18,10 @@ class CategoriesView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         construct()
+    }
+
+    override func resetView() {
+        selectedCategoryTitle = Category.pizzaSlice.title
     }
 
     private func construct() {

--- a/saving/Module/PatienceInput/View/ViewComponent/CategoryCell.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/CategoryCell.swift
@@ -5,12 +5,9 @@ class CategoryCell: UICollectionViewCell {
     static let reuseIdentifer = "category-cell"
 
     /// アイコン
-    var icon: FontAwesome.Icon {
-        get {
-            .pizzaSlice
-        }
-        set {
-            iconLabel.attributedText = NSAttributedString.icon(newValue, size: 50, style: .solid)
+    var icon: FontAwesome.Icon = .pizzaSlice {
+        didSet {
+            iconLabel.attributedText = NSAttributedString.icon(icon, size: 50, style: .solid)
         }
     }
 

--- a/saving/Module/PatienceInput/View/ViewComponent/DateView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/DateView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class DateView: UIView {
+class DateView: PatienceInputViewComponent {
     /// 入力された日付
     var selectedDate: Date {
         get {
@@ -22,9 +22,14 @@ class DateView: UIView {
         construct()
     }
 
+    override func resetView() {
+        selectedDate = Date()
+    }
+
     // MARK: Private
 
     private func construct() {
+        print(Date())
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.DateView.title
         titleLabel.font = UIFont.boldSystemFont(ofSize: 14)

--- a/saving/Module/PatienceInput/View/ViewComponent/MemoView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/MemoView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class MemoView: UIView {
+class MemoView: PatienceInputViewComponent {
     /// メモ
     var memo: String {
         get {
@@ -22,6 +22,11 @@ class MemoView: UIView {
         construct()
     }
 
+    override func resetView() {
+        memoTextView.text = L10n.MemoView.MemoTextView.placeholder
+        memoTextView.textColor = UIColor.lightGray
+    }
+
     // MARK: Private
     private func construct() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -35,7 +40,7 @@ class MemoView: UIView {
         memoTextView.backgroundColor = UIColor(hex: "DCDCDC")
         memoTextView.font = UIFont.systemFont(ofSize: 20)
         memoTextView.textContainerInset = UIEdgeInsets(top: 5, left: 20, bottom: 5, right: 20)
-        memoTextView.text = L10n.MemoView.MemoTextView.placeHolder
+        memoTextView.text = L10n.MemoView.MemoTextView.placeholder
         memoTextView.isScrollEnabled = false
         memoTextView.textColor = UIColor.lightGray
         memoTextView.delegate = self
@@ -84,7 +89,7 @@ extension MemoView: UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text == "" {
-            textView.text = L10n.MemoView.MemoTextView.placeHolder
+            textView.text = L10n.MemoView.MemoTextView.placeholder
             textView.textColor = UIColor.lightGray
         }
     }

--- a/saving/Module/PatienceInput/View/ViewComponent/MemoView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/MemoView.swift
@@ -35,9 +35,10 @@ class MemoView: UIView {
         memoTextView.backgroundColor = UIColor(hex: "DCDCDC")
         memoTextView.font = UIFont.systemFont(ofSize: 20)
         memoTextView.textContainerInset = UIEdgeInsets(top: 5, left: 20, bottom: 5, right: 20)
-        memoTextView.text = L10n.MemoView.MemoTextView.text
+        memoTextView.text = L10n.MemoView.MemoTextView.placeHolder
         memoTextView.isScrollEnabled = false
-        memoTextView.textColor = UIColor.black
+        memoTextView.textColor = UIColor.lightGray
+        memoTextView.delegate = self
         addSubview(memoTextView)
 
         memoTextView.inputAccessoryView = keyboardToolbar
@@ -70,5 +71,21 @@ class MemoView: UIView {
 
     @objc private func doneButtonAction(_ : UIBarButtonItem) {
         memoTextView.endEditing(true)
+    }
+}
+
+extension MemoView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.textColor == UIColor.lightGray {
+            textView.text = ""
+            textView.textColor = UIColor.black
+        }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text == "" {
+            textView.text = L10n.MemoView.MemoTextView.placeHolder
+            textView.textColor = UIColor.lightGray
+        }
     }
 }

--- a/saving/Module/PatienceInput/View/ViewComponent/MoneyView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/MoneyView.swift
@@ -40,7 +40,7 @@ class MoneyView: UIView {
         moneyTextField.layer.cornerRadius = 4
         moneyTextField.keyboardType = .numberPad
         moneyTextField.textColor = UIColor.black
-        moneyTextField.text = "0"
+        moneyTextField.placeholder = "0"
         addSubview(moneyTextField)
 
         moneyTextField.inputAccessoryView = keyboardToolbar

--- a/saving/Module/PatienceInput/View/ViewComponent/MoneyView.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/MoneyView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class MoneyView: UIView {
+class MoneyView: PatienceInputViewComponent {
     /// 金額
     var money: Int? {
         get {
@@ -20,6 +20,10 @@ class MoneyView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         construct()
+    }
+
+    override func resetView() {
+        moneyTextField.text = nil
     }
 
     // MARK: Private

--- a/saving/Module/PatienceInput/View/ViewComponent/PatienceInputViewComponent.swift
+++ b/saving/Module/PatienceInput/View/ViewComponent/PatienceInputViewComponent.swift
@@ -1,0 +1,8 @@
+import Foundation
+import UIKit
+
+class PatienceInputViewComponent: UIView {
+    func resetView() {
+        fatalError("this method must be overrided")
+    }
+}

--- a/saving/Resources/Localizable.strings
+++ b/saving/Resources/Localizable.strings
@@ -31,7 +31,7 @@
 
 // MemoView
 "MemoView.title" = "メモ";
-"MemoView.MemoTextView.text" = "未入力";
+"MemoView.MemoTextView.placeHolder" = "未入力";
 
 // MoneyView
 "MoneyView.title" = "金額";

--- a/saving/Resources/Localizable.strings
+++ b/saving/Resources/Localizable.strings
@@ -31,7 +31,7 @@
 
 // MemoView
 "MemoView.title" = "メモ";
-"MemoView.MemoTextView.placeHolder" = "未入力";
+"MemoView.MemoTextView.placeholder" = "未入力";
 
 // MoneyView
 "MoneyView.title" = "金額";


### PR DESCRIPTION
登録しようとした時に”未入力”や”0”(円)のプレースホルダーが入力欄に残ったままであり、消す手間が増えてしまうので入力時は消すようにしてフォーカスが外れた時に未入力だったらプレースホルダーを戻すような処理を入れた