### PR TITLE
APIに日付を送信するときに、今まで行っていたUTC時間の配慮の部分を廃止する

### DIFF
--- a/saving/API/APIClient.swift
+++ b/saving/API/APIClient.swift
@@ -14,10 +14,12 @@ class ApiClient: ApiClientInterface {
         let provider = MoyaProvider<T>()
         provider.request(request, callbackQueue: callbackQueue) { result in
             let dateFormatter: DateFormatter = {
-                let df = DateFormatter()
-                df.dateFormat = "yyyy-MM-dd"
-                df.timeZone = TimeZone(secondsFromGMT: 0)
-                return df
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+                formatter.calendar = Calendar(identifier: .iso8601)
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                return formatter
             }()
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .formatted(dateFormatter)

--- a/saving/Extension/DateExtension.swift
+++ b/saving/Extension/DateExtension.swift
@@ -70,16 +70,15 @@ extension Date {
     }
 
     var zeroclock: Date {
-        // APIリクエスト時にDate型そのままで送るとUTC時間になり、９時間前の時間になるので、９時間追加する
-        return fixed(hour: 9, minute: 0, second: 0)
+        return fixed(hour: 0, minute: 0, second: 0)
     }
 
     var beginMonth: Date {
-        fixed(day: 1, hour: 9, minute: 0, second: 0)
+        fixed(day: 1, hour: 0, minute: 0, second: 0)
     }
 
     var endMonth: Date {
-        fixed(month: month + 1, day: 0, hour: 9, minute: 0, second: 0)
+        fixed(month: month + 1, day: 0, hour: 0, minute: 0, second: 0)
     }
 
     func getDateText(format: String) -> String {


### PR DESCRIPTION
でももしかしたら、わざわざ00時00分に合わせなくてもバックエンド側でなんとかすればいいのかもしれない