### PR TITLE
APIリクエスト時にAPI側のことを考えて時間の操作をしていたが、本来やるべきではないので取り扱いをやめる

### DIFF
--- a/saving/API/TargetType/PatiencePerMonthTargetType.swift
+++ b/saving/API/TargetType/PatiencePerMonthTargetType.swift
@@ -4,9 +4,7 @@ import Moya
 struct PatiencePerMonthTargetType: ApiTargetType {
     typealias Response = PatiencesEntity
 
-    let startDate: Date
-
-    let endDate: Date
+    let date: Date
 
     var path: String { "/patiences/per_month" }
 
@@ -15,5 +13,5 @@ struct PatiencePerMonthTargetType: ApiTargetType {
     var sampleData: Data { Data() }
 
     var task: Task { .requestParameters(parameters:
-                                            ["start_date": startDate, "end_date": endDate], encoding: URLEncoding.queryString) }
+                                            ["date": date], encoding: URLEncoding.queryString) }
 }

--- a/saving/Data/DataStore/PatienceDataStore.swift
+++ b/saving/Data/DataStore/PatienceDataStore.swift
@@ -17,7 +17,7 @@ class PatienceDataStore: PatienceRepository {
         }
     }
 
-    func fetchPatienceData(date: Date) -> Single<[PatienceEntity]> {
+    func fetchPatienceDataForDay(date: Date) -> Single<[PatienceEntity]> {
         Single.create { observer -> Disposable in
             ApiClient.shared.request(PatiencePerDateTargetType(date: date)) { result in
                 switch result {
@@ -32,9 +32,9 @@ class PatienceDataStore: PatienceRepository {
         }
     }
 
-    func fetchPatienceData(startDate: Date, endDate: Date) -> Single<[PatienceEntity]> {
+    func fetchPatienceDataForMonth(date: Date) -> Single<[PatienceEntity]> {
         Single.create { observer -> Disposable in
-            ApiClient.shared.request(PatiencePerMonthTargetType(startDate: startDate, endDate: endDate)) { result in
+            ApiClient.shared.request(PatiencePerMonthTargetType(date: date)) { result in
                 switch result {
                 case let .success(record):
                     observer(.success(record.patiences))

--- a/saving/Extension/DateExtension.swift
+++ b/saving/Extension/DateExtension.swift
@@ -69,16 +69,8 @@ extension Date {
         return calendar
     }
 
-    var zeroClock: Date {
-        fixed(hour: 0, minute: 0, second: 0)
-    }
-
     var beginMonth: Date {
         fixed(day: 1, hour: 0, minute: 0, second: 0)
-    }
-
-    var endMonth: Date {
-        fixed(month: month + 1, day: 0, hour: 0, minute: 0, second: 0)
     }
 
     func getDateText(format: String) -> String {

--- a/saving/Module/PatienceAnalyze/Interactor/PatienceAnalyzeInteractor.swift
+++ b/saving/Module/PatienceAnalyze/Interactor/PatienceAnalyzeInteractor.swift
@@ -7,9 +7,7 @@ class PatienceAnalyzeInteractor: PatienceAnalyzeUsecase {
     var output: PatienceAnalyzeOutput?
 
     func fetchDataFromMonth(date: Date) {
-        let startDate = date.beginMonth
-        let endDate = date.endMonth
-        repository.fetchPatienceData(startDate: startDate, endDate: endDate).subscribe { [weak self] observer in
+        repository.fetchPatienceDataForMonth(date: date).subscribe { [weak self] observer in
             switch observer {
             case .success(let records):
                 self?.output?.outputFetchRecords(records: records)
@@ -21,7 +19,7 @@ class PatienceAnalyzeInteractor: PatienceAnalyzeUsecase {
     }
 
     func fetchDataFromDate(date: Date) {
-        repository.fetchPatienceData(date: date).subscribe { [weak self] observer in
+        repository.fetchPatienceDataForDay(date: date).subscribe { [weak self] observer in
             switch observer {
             case .success(let records):
                 self?.output?.outputFetchRecords(records: records)

--- a/saving/Module/PatienceAnalyze/View/ViewComponent/SelectableDateStylePickerTextField.swift
+++ b/saving/Module/PatienceAnalyze/View/ViewComponent/SelectableDateStylePickerTextField.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// 日付のピック方法を選べるdatePickerTextField
 class SelectableDateStylePickerTextField: PatienceTextField {
-    var selectedDate = Date().zeroClock {
+    var selectedDate = Date() {
         didSet {
             if isSingleDaySelect {
                 text = selectedDate.getDateText(format: DateStringConverter.dateFormatJapanese)
@@ -97,7 +97,7 @@ class SelectableDateStylePickerTextField: PatienceTextField {
     }()
 
     @objc private func doneButtonAction(_ : UIBarButtonItem) {
-        selectedDate = datePickerView.date.zeroClock
+        selectedDate = datePickerView.date
         endEditing(true)
         dateChangeAction?(selectedDate)
     }

--- a/saving/Module/PatienceCalendar/Interactor/PatienceCalendarInteractor.swift
+++ b/saving/Module/PatienceCalendar/Interactor/PatienceCalendarInteractor.swift
@@ -8,7 +8,7 @@ class PatienceCalendarInteractor: PatienceCalendarUsecase {
     var output: PatienceCalendarInteractorOutput?
 
     func fetchPatienceData(date: Date) {
-        repository.fetchPatienceData(date: date)
+        repository.fetchPatienceDataForDay(date: date)
             .subscribe { observer in
                 switch observer {
                 case .success(let records):
@@ -21,9 +21,7 @@ class PatienceCalendarInteractor: PatienceCalendarUsecase {
     }
 
     func fetchDataFromMonth(date: Date) {
-        let startDate = date.beginMonth
-        let endDate = date.endMonth
-        repository.fetchPatienceData(startDate: startDate, endDate: endDate).subscribe { [weak self]observer in
+        repository.fetchPatienceDataForMonth(date: date).subscribe { [weak self]observer in
             switch observer {
             case .success(let records):
                 self?.output?.outputFetchRecordsPerMonth(records: records)

--- a/saving/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
+++ b/saving/Module/PatienceCalendar/View/PatienceCalendarViewController.swift
@@ -10,7 +10,7 @@ class PatienceCalenderViewController: UIViewController, PatienceCalendarView {
         }
     }
     ///  選択されている日付
-    var selectedDate = Date().zeroClock {
+    var selectedDate = Date() {
         didSet {
             presenter.selectedDateDidChange(date: selectedDate)
             recordListHeaderView.selectedMonth = Calendar(identifier: .gregorian).component(.month, from: selectedDate)

--- a/saving/Module/PatienceInput/PatienceInputContract.swift
+++ b/saving/Module/PatienceInput/PatienceInputContract.swift
@@ -87,12 +87,11 @@ protocol PatienceRepository {
 
     /// データをフェッチする
     /// - parameter data:日付
-    func fetchPatienceData(date: Date) -> Single<[PatienceEntity]>
+    func fetchPatienceDataForDay(date: Date) -> Single<[PatienceEntity]>
 
-    /// 指定期間のデータをフェッチする
-    /// - parameter startDate:開始日
-    /// - parameter endDate:終了日
-    func fetchPatienceData(startDate: Date, endDate: Date) -> Single<[PatienceEntity]>
+    /// 指定日月のデータをフェッチする
+    /// - parameter date:指定日
+    func fetchPatienceDataForMonth(date: Date) -> Single<[PatienceEntity]>
 
     /// データをupdateする
     /// - parameter id:ID


### PR DESCRIPTION
日付指定のAPIを叩くときに時間を12時に合わせたり、期間も月初と月終をクライアント側で指定していたが、本来はバックエンド側で行うものなので、クライアント側では関与しないようにする